### PR TITLE
Per-knock vetting room with wikipedia-haiku captcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This is a **specific instance**, not a generic example — for the example, see
 
 - Custom landing page at `/` and per-invite `/join?code=…` page (served by a
   small nginx sidecar in front of continuwuity)
-- `knock-approver`: a tiny Python service that auto-approves Matrix `knock`
-  events on the Shape Rotator space when the knock `reason` matches a code
-  in `/data/codes.json`
+- `knock-approver`: a tiny Python service. When a Matrix `knock` on the
+  Shape Rotator space carries a `reason` matching a code in `/data/codes.json`,
+  the approver creates a fresh **per-knock vetting room**, invites the
+  knocker into it, and posts a wikipedia-fact haiku captcha. Only after
+  the knocker replies with a valid haiku does the approver invite them to
+  the space proper.
 - dstack-ingress with Namecheap DNS-01 Let's Encrypt for the custom domain
 
 ## Layout
@@ -25,10 +28,14 @@ landing/
   nginx.conf          routes / /join /signup to static files, /signup/api to the
                       approver service, everything else to continuwuity
 knock-approver/
-  approver.py         two jobs: (a) long-polls /sync and approves knocks whose
-                      reason matches /data/codes.json; (b) aiohttp.web server
-                      on :8001 exposing POST /signup/api which validates a code
-                      from /data/signup_codes.json, calls continuwuity register
+  approver.py         two jobs: (a) long-polls /sync — when a knock matches
+                      /data/codes.json it creates a per-knock vetting room
+                      (state in /data/vetting.json), posts a wikipedia haiku
+                      captcha, and invites the knocker to the space only after
+                      they reply with a valid 3-line haiku containing the
+                      keyword; (b) aiohttp.web server on :8001 exposing POST
+                      /signup/api which validates a code from
+                      /data/signup_codes.json, calls continuwuity register
                       with the server-side CONDUWUIT_REGISTRATION_TOKEN, and
                       auto-invites the new user to the space
 skills/
@@ -97,11 +104,22 @@ the CVM (SSH + docker exec) to add more.
    Rotator in Element" button.
 3. Element opens on `matrix.to/#/#shape-rotator:mtrx.shaperotator.xyz` →
    they click "Request to join" and paste the code as the reason.
-4. `knock-approver` sees the knock in the next `/sync` batch, matches the
-   code against `/data/codes.json`, and POSTs `/invite` → the user gets an
-   invite in their client.
-5. Accepting the invite joins the space; the `restricted` rule on child
-   rooms lets them auto-join General / Announcements / Bot Noise.
+4. `knock-approver` sees the knock in the next `/sync` batch and matches
+   the code against `/data/codes.json`. Instead of inviting straight to
+   the space, it creates a fresh **per-knock vetting room** and invites
+   only the knocker, then posts a captcha: "write a 3-line haiku about
+   *<random Wikipedia article title>*; include the word *<keyword>*."
+5. The user accepts the vetting-room invite, sets their Element
+   displayname (the bot uses it as their handle), and replies with a
+   haiku. The approver checks: 3 non-empty lines, 30–400 chars, contains
+   the required keyword. They get up to `VETTING_MAX_TRIES` attempts
+   (default 3); on success the approver invites them to the actual
+   space, on failure the bot leaves and the room dies.
+6. Accepting the space invite joins them in; the `restricted` rule on
+   child rooms lets them auto-join General / Announcements / Bot Noise.
+
+Stale, un-promoted vetting rooms are abandoned by the bot after
+`VETTING_TIMEOUT_SEC` (default 7200 = 2 h).
 
 ## Managing invite codes
 

--- a/STATE.md
+++ b/STATE.md
@@ -41,10 +41,12 @@ Running at: https://mtrx.shaperotator.xyz
 - `continuwuity` (Rust Matrix homeserver, RocksDB)
 - `landing` (nginx serving `/`, `/join?code=…`, `/signup` + proxying
   `/signup/api*` to the approver)
-- `knock-approver` (single Python process that does (a) /sync knock auto-
-  approval for community-invite codes, (b) HTTP `/signup/api` for account
-  creation + full onboarding dance, (c) HTTP `/signup/api/crosssign` for
-  Paste B cross-signing bootstrap)
+- `knock-approver` (single Python process that does (a) /sync knock
+  handling — on a valid code, spawns a fresh per-knock vetting room and
+  posts a wikipedia-fact haiku captcha; only invites to the space after
+  the knocker replies with a valid haiku, (b) HTTP `/signup/api` for
+  account creation + full onboarding dance, (c) HTTP `/signup/api/crosssign`
+  for Paste B cross-signing bootstrap)
 
 **Two kinds of community access:**
 - *Invite code* — `/join?code=X`. Federates a guest in; they bring their

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -96,12 +96,81 @@ def merge_seed(path, env_key):
         print(f"seeded {added} new entries into {path.name} from {env_key}", flush=True)
 
 
-# --- Knock approval ---
+# --- Knock approval (per-knock vetting room with a haiku captcha) ---
+#
+# A valid knock no longer invites straight to the space. Instead the approver
+# creates a fresh 1:1 vetting room (invite-only, the knocker is the only
+# invitee) and posts a wikipedia-fact haiku challenge. Once the knocker joins
+# and replies with a 3-line haiku that contains the required keyword, the bot
+# invites them to the space — and the existing `restricted` join rule on
+# child rooms takes over from there.
 
-async def approve_knock(session, room_id, user_id):
-    url = f"{HS}/_matrix/client/v3/rooms/{room_id}/invite"
-    async with session.post(url, json={"user_id": user_id, "reason": "auto-approved"}) as r:
+VETTING_PATH      = Path(os.environ.get("VETTING_PATH",       "/data/vetting.json"))
+VETTING_TIMEOUT   = int(os.environ.get("VETTING_TIMEOUT_SEC", "7200"))
+VETTING_MAX_TRIES = int(os.environ.get("VETTING_MAX_TRIES",   "3"))
+
+# Stop-words too generic to use as the haiku-keyword constraint.
+_STOPWORDS = {"with", "from", "that", "this", "their", "have", "been",
+              "were", "into", "over", "when", "what", "where", "which",
+              "would", "could", "should", "about", "after", "before"}
+
+
+async def _fetch_wiki_challenge():
+    """Random wikipedia article -> (title, longest non-stopword >=4-char alpha word)."""
+    url = "https://en.wikipedia.org/api/rest_v1/page/random/summary"
+    headers = {"User-Agent": "shape-rotator-vetting/1.0", "Accept": "application/json"}
+    async with aiohttp.ClientSession(headers=headers) as s:
+        async with s.get(url) as r:
+            body = await r.json()
+    title = body["title"]
+    words = [w.strip(".,;:'\"()[]") for w in title.split()]
+    candidates = [w for w in words
+                  if len(w) >= 4 and w.isalpha() and w.lower() not in _STOPWORDS]
+    keyword = max(candidates, key=len)
+    return title, keyword
+
+
+async def _send_msg(session, room_id, text):
+    txn = f"m{int(time.time()*1000)}-{os.urandom(2).hex()}"
+    url = f"{HS}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn}"
+    async with session.put(url, json={"msgtype": "m.text", "body": text}) as r:
+        return r.status
+
+
+async def _create_vetting_room(session, mxid):
+    body = {
+        "preset": "private_chat",   # creator PL 100, invitee PL 0
+        "invite": [mxid],
+        "is_direct": False,
+        "name":  f"shape-rotator vetting · {mxid}",
+        "topic": "captcha airlock — answer the challenge to be invited to the space.",
+    }
+    async with session.post(f"{HS}/_matrix/client/v3/createRoom", json=body) as r:
+        if r.status != 200:
+            return None, await r.text()
+        return (await r.json())["room_id"], None
+
+
+def _vet(displayname, message, keyword):
+    if not displayname:
+        return False, "set a displayname in element first, then re-paste the haiku"
+    text = (message or "").strip()
+    lines = [l for l in text.splitlines() if l.strip()]
+    if len(lines) != 3:
+        return False, "haiku is three lines"
+    if not (30 <= len(text) <= 400):
+        return False, "haiku should be roughly 30–400 chars"
+    if keyword.lower() not in text.lower():
+        return False, f"include the word '{keyword}' somewhere"
+    return True, "ok"
+
+
+async def _promote(session, mxid):
+    url = f"{HS}/_matrix/client/v3/rooms/{SPACE_ID}/invite"
+    async with session.post(url,
+                            json={"user_id": mxid, "reason": "vetted via airlock"}) as r:
         return r.status, await r.text()
+
 
 async def handle_knock(session, room_id, user_id, reason):
     code = (reason or "").strip()
@@ -111,18 +180,36 @@ async def handle_knock(session, room_id, user_id, reason):
         audit({"type": "knock_rejected", "user": user_id, "room": room_id, "reason": reason})
         print(f"[knock rejected] {user_id}", flush=True)
         return
-    status, body = await approve_knock(session, room_id, user_id)
-    if status == 200:
-        entry["uses_remaining"] -= 1
-        codes[code] = entry
-        _save(CODES_PATH, codes)
-        audit({"type": "knock_approved", "user": user_id, "room": room_id, "code": code,
-               "uses_left": entry["uses_remaining"]})
-        print(f"[knock approved] {user_id} via {code} (left={entry['uses_remaining']})", flush=True)
-    else:
-        audit({"type": "knock_invite_failed", "user": user_id, "room": room_id, "code": code,
-               "status": status, "body": body[:200]})
-        print(f"[knock failed] {user_id} status={status}", flush=True)
+
+    title, keyword = await _fetch_wiki_challenge()
+    vroom, err = await _create_vetting_room(session, user_id)
+    if not vroom:
+        audit({"type": "vetting_room_failed", "user": user_id,
+               "code": code, "err": (err or "")[:200]})
+        print(f"[vetting room failed] {user_id}: {err[:200]}", flush=True)
+        return
+
+    entry["uses_remaining"] -= 1
+    codes[code] = entry
+    _save(CODES_PATH, codes)
+
+    state = _load(VETTING_PATH)
+    state[vroom] = {
+        "mxid": user_id, "code": code, "created": time.time(),
+        "title": title, "keyword": keyword,
+        "tries_left": VETTING_MAX_TRIES, "promoted": False, "closed": False,
+    }
+    _save(VETTING_PATH, state)
+
+    await _send_msg(session, vroom,
+        f"hi {user_id} — quick captcha to keep bots out of shape rotator.\n\n"
+        f"write a 3-line haiku about: {title}\n"
+        f"include the word \"{keyword}\" somewhere.\n"
+        f"reply in this room. {VETTING_MAX_TRIES} tries.")
+    audit({"type": "vetting_room_created", "user": user_id, "code": code,
+           "room": vroom, "title": title, "keyword": keyword})
+    print(f"[vetting] {user_id} -> {vroom} ({title!r} / {keyword})", flush=True)
+
 
 def iter_knock_events(rooms_data):
     for room_id, rd in rooms_data.get("join", {}).items():
@@ -136,6 +223,88 @@ def iter_knock_events(rooms_data):
                 if c.get("membership") != "knock":
                     continue
                 yield room_id, ev["state_key"], c.get("reason", "")
+
+
+def iter_vetting_rooms(rooms_data, vetting_state):
+    """For each open vetting room we own, yield
+    (room_id, meta, join_event_for_user_or_None, list_of_user_messages)."""
+    for room_id, rd in rooms_data.get("join", {}).items():
+        meta = vetting_state.get(room_id)
+        if not meta or meta.get("promoted") or meta.get("closed"):
+            continue
+        join_ev = None
+        for section in ("state", "timeline"):
+            for ev in rd.get(section, {}).get("events", []):
+                if (ev.get("type") == "m.room.member"
+                        and ev.get("state_key") == meta["mxid"]
+                        and (ev.get("content") or {}).get("membership") == "join"):
+                    join_ev = ev
+        msgs = [ev for ev in rd.get("timeline", {}).get("events", [])
+                if ev.get("type") == "m.room.message"
+                and ev.get("sender") == meta["mxid"]]
+        yield room_id, meta, join_ev, msgs
+
+
+async def process_vetting_room(session, room_id, meta, join_ev, msgs):
+    """Process new messages in one vetting room. Returns updated meta or None."""
+    if not join_ev or not msgs:
+        return None
+    displayname = (join_ev.get("content") or {}).get("displayname", "")
+    keyword = meta["keyword"]
+    for msg in msgs:
+        text = (msg.get("content") or {}).get("body", "")
+        ok, why = _vet(displayname, text, keyword)
+        if ok:
+            st, body = await _promote(session, meta["mxid"])
+            if st == 200:
+                meta["promoted"] = True
+                meta["promoted_at"] = time.time()
+                meta["displayname"] = displayname
+                await _send_msg(session, room_id,
+                    "nice — invited you to shape rotator. you can leave this room.")
+                audit({"type": "promoted", "user": meta["mxid"],
+                       "displayname": displayname, "room": room_id})
+                print(f"[promoted] {meta['mxid']} ({displayname})", flush=True)
+            else:
+                audit({"type": "promote_failed", "user": meta["mxid"],
+                       "status": st, "body": body[:200]})
+                print(f"[promote failed] {meta['mxid']} status={st}", flush=True)
+            return meta
+        meta["tries_left"] -= 1
+        if meta["tries_left"] <= 0:
+            await _send_msg(session, room_id,
+                "out of tries. closing this room — get a fresh code and try again.")
+            async with session.post(
+                f"{HS}/_matrix/client/v3/rooms/{room_id}/leave",
+                json={"reason": "vetting failed"}) as r:
+                pass
+            meta["closed"] = True
+            meta["closed_reason"] = "tries_exhausted"
+            audit({"type": "vetting_failed", "user": meta["mxid"], "room": room_id})
+            return meta
+        await _send_msg(session, room_id,
+            f"not yet — {why}. {meta['tries_left']} tries left.")
+    return meta
+
+
+async def cleanup_stale_vetting(session, vetting_state):
+    """Leave vetting rooms older than VETTING_TIMEOUT. Returns True if state changed."""
+    now = time.time()
+    dirty = False
+    for vroom, meta in list(vetting_state.items()):
+        if meta.get("promoted") or meta.get("closed"):
+            continue
+        if now - meta.get("created", 0) > VETTING_TIMEOUT:
+            async with session.post(
+                f"{HS}/_matrix/client/v3/rooms/{vroom}/leave",
+                json={"reason": "vetting timeout"}) as r:
+                pass
+            meta["closed"] = True
+            meta["closed_reason"] = "timeout"
+            audit({"type": "vetting_timeout", "user": meta["mxid"], "room": vroom})
+            dirty = True
+    return dirty
+
 
 async def sync_loop():
     since = SYNC_STATE.read_text().strip() if SYNC_STATE.exists() else None
@@ -160,8 +329,22 @@ async def sync_loop():
                 continue
             since = data["next_batch"]
             SYNC_STATE.write_text(since)
+
             for room_id, user_id, reason in iter_knock_events(data.get("rooms", {})):
                 await handle_knock(s, room_id, user_id, reason)
+
+            vetting_state = _load(VETTING_PATH)
+            v_dirty = False
+            for vroom, meta, join_ev, msgs in iter_vetting_rooms(
+                    data.get("rooms", {}), vetting_state):
+                updated = await process_vetting_room(s, vroom, meta, join_ev, msgs)
+                if updated is not None:
+                    vetting_state[vroom] = updated
+                    v_dirty = True
+            if await cleanup_stale_vetting(s, vetting_state):
+                v_dirty = True
+            if v_dirty:
+                _save(VETTING_PATH, vetting_state)
 
 
 # --- Signup auth proxy ---
@@ -538,10 +721,11 @@ async def run_http():
 
 async def main():
     print(f"approver starting. space={SPACE_ID} signup_enabled={bool(REG_TOKEN)}", flush=True)
-    for p in (CODES_PATH, SIGNUP_PATH, LOG_PATH):
+    for p in (CODES_PATH, SIGNUP_PATH, LOG_PATH, VETTING_PATH):
         p.parent.mkdir(parents=True, exist_ok=True)
-    if not CODES_PATH.exists():  _save(CODES_PATH,  {})
-    if not SIGNUP_PATH.exists(): _save(SIGNUP_PATH, {})
+    if not CODES_PATH.exists():   _save(CODES_PATH,   {})
+    if not SIGNUP_PATH.exists():  _save(SIGNUP_PATH,  {})
+    if not VETTING_PATH.exists(): _save(VETTING_PATH, {})
     merge_seed(CODES_PATH,  "INITIAL_CODES")
     merge_seed(SIGNUP_PATH, "INITIAL_SIGNUP_CODES")
 

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -114,12 +114,24 @@ def test_signup_path():
     return mxid
 
 
-# --- Path B: knock (federated-guest style) ---
+# --- Path B: knock -> vetting room -> haiku captcha -> space invite ---
+
+import re
+
+def _wait_for_invite(token, predicate, timeout=15):
+    """Poll /sync until an invited room matches predicate(rid). Returns rid or None."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        _s, sync = http("GET", f"{HS}/_matrix/client/v3/sync?timeout=0", token=token)
+        for rid in sync.get("rooms", {}).get("invite", {}).keys():
+            if predicate(rid):
+                return rid
+        time.sleep(1)
+    return None
+
 
 def test_knock_path():
     # Register a throwaway account on THIS server to simulate a federated guest.
-    # (In real federation the guest's account lives elsewhere, but the knock
-    # endpoint behavior is the same.)
     username = f"smoke_knock_{int(time.time())}_{secrets.token_hex(2)}"
     print(f"\n[knock] test account: {username}", flush=True)
 
@@ -141,25 +153,64 @@ def test_knock_path():
     token = r["access_token"]
     mxid  = r["user_id"]
 
+    # _vet requires a non-empty displayname; set one before knocking.
+    http("PUT", f"{HS}/_matrix/client/v3/profile/{urllib.parse.quote(mxid)}/displayname",
+         token=token, body={"displayname": f"smoke-{secrets.token_hex(2)}"})
+
     status, _ = http(
         "POST",
         f"{HS}/_matrix/client/v3/knock/{urllib.parse.quote(SPACE_ID)}",
         token=token, body={"reason": KNOCK_CODE})
     log("knock posted", status == 200, f"status={status}")
 
-    # Poll for auto-approval (should arrive within a few seconds)
-    deadline = time.time() + 15
-    got_invite = False
+    # Approver should invite to a NEW per-knock vetting room (not the space).
+    space_prefix = SPACE_ID.split(":")[0]
+    vetting_room = _wait_for_invite(token, lambda rid: rid.split(":")[0] != space_prefix)
+    log("vetting room invite within 15s", bool(vetting_room),
+        f"room={vetting_room}")
+    if not vetting_room:
+        return [mxid]
+
+    status, _ = http("POST",
+                     f"{HS}/_matrix/client/v3/join/{urllib.parse.quote(vetting_room)}",
+                     token=token, body={})
+    log("joined vetting room", status == 200, f"status={status}")
+
+    # Pull the challenge — server posts it after createRoom, but the bot's
+    # message may take a beat to be visible to a fresh joiner.
+    keyword = None
+    deadline = time.time() + 10
     while time.time() < deadline:
         _s, sync = http("GET", f"{HS}/_matrix/client/v3/sync?timeout=0", token=token)
-        invites = list(sync.get("rooms", {}).get("invite", {}).keys())
-        if any(rid.split(":")[0] == SPACE_ID.split(":")[0] for rid in invites):
-            got_invite = True
+        joined = sync.get("rooms", {}).get("join", {}).get(vetting_room, {})
+        for ev in joined.get("timeline", {}).get("events", []):
+            if ev.get("type") != "m.room.message":
+                continue
+            body = (ev.get("content") or {}).get("body", "")
+            m = re.search(r'include the word "([^"]+)"', body)
+            if m:
+                keyword = m.group(1)
+                break
+        if keyword:
             break
         time.sleep(1)
-    log("auto-approved within 15s", got_invite)
+    log("challenge keyword visible", bool(keyword), f"keyword={keyword!r}")
+    if not keyword:
+        return [mxid]
 
-    # Try a knock with a bogus code; should stay unapproved
+    haiku = f"silent {keyword} hum\nfloating in the morning fog\nspring wind blowing through"
+    status, _ = http(
+        "PUT",
+        f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(vetting_room)}"
+        f"/send/m.room.message/smoke-haiku-{int(time.time())}",
+        token=token, body={"msgtype": "m.text", "body": haiku})
+    log("haiku sent", status == 200, f"status={status}")
+
+    # Now wait for the actual space invite.
+    space_invite = _wait_for_invite(token, lambda rid: rid.split(":")[0] == space_prefix)
+    log("space invite after vetting (within 15s)", bool(space_invite))
+
+    # Bad-code path: knock with a bogus code; nothing should ever be invited.
     username2 = f"smoke_badcode_{int(time.time())}_{secrets.token_hex(2)}"
     _s, init = http("POST", f"{HS}/_matrix/client/v3/register", body={})
     sess2 = init["session"]
@@ -177,8 +228,8 @@ def test_knock_path():
     time.sleep(8)
     _s, sync = http("GET", f"{HS}/_matrix/client/v3/sync?timeout=0", token=bad_token)
     invites = list(sync.get("rooms", {}).get("invite", {}).keys())
-    log("bad code stays unapproved",
-        not any(rid.split(":")[0] == SPACE_ID.split(":")[0] for rid in invites))
+    log("bad code: no invites at all", len(invites) == 0,
+        f"invites={invites}")
 
     return [mxid, bad_mxid]
 


### PR DESCRIPTION
## Summary

A valid knock no longer goes straight to a space invite. The approver creates a fresh per-knock room (`private_chat`, knocker is the only invitee) and posts a captcha:

> write a 3-line haiku about: *&lt;random wikipedia article title&gt;*
> include the word *&lt;keyword&gt;* somewhere.

Only on a valid reply (3 non-empty lines, 30–400 chars, contains the keyword, knocker has a non-empty Element displayname) does the bot invite them to the space — the existing `restricted` join rule on child rooms takes over from there.

Why this shape:
- Avoids a public lobby room, which would be a spam target.
- Each new arrival gets a private 1:1 with the bot by construction; their Element displayname falls out of the join event the bot can read.
- Stale, un-promoted vetting rooms are abandoned after `VETTING_TIMEOUT_SEC` (default 2 h).

## Changes

- **`knock-approver/approver.py`** — new helpers `_fetch_wiki_challenge`, `_create_vetting_room`, `_send_msg`, `_vet`, `_promote`, `iter_vetting_rooms`, `process_vetting_room`, `cleanup_stale_vetting`. `handle_knock` rewired; `sync_loop` runs the vetting processor + cleanup after each `/sync` batch. New env: `VETTING_PATH` (default `/data/vetting.json`, lands on the existing `knock-data` volume), `VETTING_TIMEOUT_SEC=7200`, `VETTING_MAX_TRIES=3`.
- **`tests/smoke.py`** — knock path now drives the full new flow: vetting-room invite arrives, regex out the keyword from the welcome, send a haiku, expect the space invite. Bad-code path asserts no invites at all.
- **`README.md` + `STATE.md`** — operator-facing flow descriptions updated.

## Caveats

- Vetting room is **cleartext**. The approver speaks raw HTTP; an `m.room.encryption` initial state would block the welcome message. Moving the bot to a real client (mautrix-python, like Paste C) is the path to E2EE — tracked separately.
- No deploy. CVM is still running the old approver; this is repo-only until reviewed and shipped.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — both files parse.
- [x] Unit-tested `_vet` against missing displayname / wrong line count / missing keyword / too-short / happy-path.
- [x] Unit-tested `iter_vetting_rooms` against synthetic sync data.
- [ ] Live: `cd dev && docker-compose up -d && python3 bootstrap.py` then `python3 tests/smoke.py` against the dev stack.
- [ ] Live against staging CVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)