### PR TITLE
Containerized e2e harness + auto-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,88 @@
+name: deploy
+
+# Auto-deploy mtrx.shaperotator.xyz on every push to main, gated on the
+# e2e test workflow. To trigger an out-of-band deploy (rotating a secret,
+# emergency push), use the "Run workflow" button (workflow_dispatch).
+#
+# Required GitHub secrets — set under Settings → Secrets and variables →
+# Actions:
+#
+#   PHALA_API_KEY            phala CLI api token; deploys against the cvm
+#   NAMECHEAP_USERNAME       DNS-01 LE creds for dstack-ingress
+#   NAMECHEAP_API_KEY        ditto
+#   REGISTRATION_TOKEN       continuwuity registration token
+#   KNOCK_APPROVER_TOKEN     access token of @shape-rotator-2 (PL ≥ 50 in space)
+#   DSTACK_AUTHORIZED_KEYS   ssh authorized_keys for the CVM (one line)
+#   ONBOARDING_INVITER_MXID  e.g. @socrates1024:matrix.org
+#   SHAPEROTATOR_SPACE_ID    !4FL8uL5OEYL...mm-g (unsuffixed)
+#   SPACE_CHILD_IDS          comma-separated unsuffixed child ids
+#   INITIAL_CODES            JSON, can be {} (no extra knock codes)
+#   INITIAL_SIGNUP_CODES     JSON, can be {} (no extra signup codes)
+#
+# The CVM ID `dstack-matrix` is the name on the Phala dashboard. Change it
+# below if the CVM is renamed or replaced.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    uses: ./.github/workflows/test.yml
+
+  deploy:
+    needs: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: install phala CLI
+        run: npm install -g phala
+
+      - name: build .env
+        env:
+          NAMECHEAP_USERNAME: ${{ secrets.NAMECHEAP_USERNAME }}
+          NAMECHEAP_API_KEY: ${{ secrets.NAMECHEAP_API_KEY }}
+          REGISTRATION_TOKEN: ${{ secrets.REGISTRATION_TOKEN }}
+          KNOCK_APPROVER_TOKEN: ${{ secrets.KNOCK_APPROVER_TOKEN }}
+          DSTACK_AUTHORIZED_KEYS: ${{ secrets.DSTACK_AUTHORIZED_KEYS }}
+          ONBOARDING_INVITER_MXID: ${{ secrets.ONBOARDING_INVITER_MXID }}
+          SHAPEROTATOR_SPACE_ID: ${{ secrets.SHAPEROTATOR_SPACE_ID }}
+          SPACE_CHILD_IDS: ${{ secrets.SPACE_CHILD_IDS }}
+          INITIAL_CODES: ${{ secrets.INITIAL_CODES }}
+          INITIAL_SIGNUP_CODES: ${{ secrets.INITIAL_SIGNUP_CODES }}
+        run: |
+          {
+            echo "NAMECHEAP_USERNAME=$NAMECHEAP_USERNAME"
+            echo "NAMECHEAP_API_KEY=$NAMECHEAP_API_KEY"
+            echo "REGISTRATION_TOKEN=$REGISTRATION_TOKEN"
+            echo "KNOCK_APPROVER_TOKEN=$KNOCK_APPROVER_TOKEN"
+            echo "DSTACK_AUTHORIZED_KEYS=$DSTACK_AUTHORIZED_KEYS"
+            echo "ONBOARDING_INVITER_MXID=$ONBOARDING_INVITER_MXID"
+            echo "SHAPEROTATOR_SPACE_ID=$SHAPEROTATOR_SPACE_ID"
+            echo "SPACE_CHILD_IDS=$SPACE_CHILD_IDS"
+            echo "INITIAL_CODES=$INITIAL_CODES"
+            echo "INITIAL_SIGNUP_CODES=$INITIAL_SIGNUP_CODES"
+          } > .env
+          bash deploy/encode_env.sh
+
+      - name: phala deploy
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_API_KEY }}
+        run: |
+          phala deploy \
+            --api-token "$PHALA_CLOUD_API_KEY" \
+            --cvm-id dstack-matrix \
+            --compose docker-compose.yml \
+            --env-file .env \
+            --wait

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # Reusable from deploy.yml so a deploy is gated on the same e2e test run.
+  workflow_call:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: full e2e stack
+        run: bash tests/run_e2e.sh

--- a/dev/bootstrap.py
+++ b/dev/bootstrap.py
@@ -26,8 +26,12 @@ import json, os, re, secrets, subprocess, sys, time, urllib.error, urllib.parse,
 from pathlib import Path
 
 HS = os.environ.get("DEV_HS", "http://localhost:46167").rstrip("/")
-REG_TOKEN = "dev-token"  # matches dev/docker-compose.yml
-STATE = Path(__file__).parent / ".dev-state.json"
+REG_TOKEN = os.environ.get("CONDUWUIT_REGISTRATION_TOKEN", "dev-token")
+STATE = Path(os.environ.get("DEV_STATE_PATH",
+                            str(Path(__file__).parent / ".dev-state.json")))
+# Pre-supplied bootstrap token (e.g. CI scrapes from `docker logs` on the host
+# and passes it in here so the bootstrap container doesn't need docker access).
+ENV_BOOTSTRAP_TOKEN = os.environ.get("CONDUWUIT_BOOTSTRAP_TOKEN", "").strip()
 
 ADMIN_USERNAME = "admin"
 ADMIN_PASSWORD = "dev-admin-password-longenough"
@@ -73,8 +77,11 @@ def save_state(state):
 
 def read_bootstrap_token():
     """Continuwuity prints a one-time registration token on first boot, before
-    the configured CONDUWUIT_REGISTRATION_TOKEN takes effect. Grab it from
-    the container logs so the first user can register."""
+    the configured CONDUWUIT_REGISTRATION_TOKEN takes effect. Either pass it
+    in via CONDUWUIT_BOOTSTRAP_TOKEN env (CI / containerised case where
+    docker isn't available) or scrape it from container logs (local dev)."""
+    if ENV_BOOTSTRAP_TOKEN:
+        return ENV_BOOTSTRAP_TOKEN
     try:
         logs = subprocess.run(
             ["docker", "logs", "dev-continuwuity-1"],
@@ -257,6 +264,8 @@ def main():
     echo(f"export HS={HS!r}")
     echo(f"export HS_PUBLIC={HS!r}")
     echo(f"export MATRIX_TOKEN={admin_token!r}")
+    echo(f"export ADMIN_TOKEN={admin_token!r}")
+    echo(f"export ADMIN_MXID={admin_mxid!r}")
     # Use whatever form createRoom returned. Continuwuity is inconsistent
     # about whether room IDs come back with or without the `:server` suffix
     # — /invite rejects the wrong form with a misleading error. Trust the
@@ -265,11 +274,8 @@ def main():
     echo(f"export SPACE_CHILD_IDS={','.join(child_ids)!r}")
     echo(f"export CONDUWUIT_REGISTRATION_TOKEN={REG_TOKEN!r}")
     echo(f"export ONBOARDING_INVITER_MXID={admin_mxid!r}")
-    echo(f"export INITIAL_CODES={signup_seed!r}".replace("'", "\\'")  # bash-safe
-          if False else f"export INITIAL_CODES={json.dumps(json.loads(signup_seed))!r}")
-    echo(f"export INITIAL_SIGNUP_CODES={json.dumps(json.loads(signup_seed))!r}")
-    echo(f"# Note: in this dev env the SAME code works for both signup and knock if you want,")
-    echo(f"# but the seeds above assign them separately:")
+    echo(f"export INITIAL_CODES={knock_seed!r}")
+    echo(f"export INITIAL_SIGNUP_CODES={signup_seed!r}")
     echo(f"export DEV_SIGNUP_CODE={signup_code!r}")
     echo(f"export DEV_KNOCK_CODE={knock_code!r}")
     echo(f"# Admin MXID: {admin_mxid}")

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -247,9 +247,14 @@ def iter_vetting_rooms(rooms_data, vetting_state):
 
 async def process_vetting_room(session, room_id, meta, join_ev, msgs):
     """Process new messages in one vetting room. Returns updated meta or None."""
-    if not join_ev or not msgs:
-        return None
-    displayname = (join_ev.get("content") or {}).get("displayname", "")
+    # Persist displayname the first time we see the user's join event — Matrix
+    # /sync returns the join event in one batch and the user's later messages
+    # in subsequent batches, so we can't require both in the same cycle.
+    if join_ev:
+        meta["displayname"] = (join_ev.get("content") or {}).get("displayname", "")
+    if not msgs:
+        return meta if join_ev else None
+    displayname = meta.get("displayname", "")
     keyword = meta["keyword"]
     for msg in msgs:
         text = (msg.get("content") or {}).get("body", "")

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,22 @@
+# Test-runner image. Carries libolm + every Python crypto dep needed by
+# the E2EE tests. Source code is bind-mounted at /repo at runtime — no
+# COPY here, so a code change is a fast container restart, not a rebuild.
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libolm3 libolm-dev gcc curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        aiohttp \
+        cryptography \
+        'mautrix[e2be]' \
+        asyncpg \
+        aiosqlite \
+        'matrix-nio[e2e]' \
+        unpaddedbase64 \
+        base58 \
+        pyaes \
+        python-olm
+
+WORKDIR /repo

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,42 +1,122 @@
 # Tests
 
-## `smoke.py` — end-to-end smoke test
+The full PR gate is `bash tests/run_e2e.sh` — see "Running everything" below.
 
-Exercises the two onboarding paths end-to-end against any configured
-homeserver (prod by default). Uses only Python stdlib.
+Three test files. Each addresses a different failure mode and runs as part
+of the e2e gate.
 
-Checks:
-- `POST /signup/api` returns 200 and every `steps` value is `true`
-- The new account's own `/sync` reflects space + child-room membership
-- `/knock` with a valid code is auto-approved within 15s
-- `/knock` with a bogus code is NOT approved after 8s
-- Cleans up by kicking all test users before exit
+## What each test covers
 
-### Against prod
+### `smoke.py` — flow / integration
+
+Stdlib only. End-to-end *flow* check, cleartext (no Olm) — fast and easy
+to debug when something at the HTTP level breaks.
+
+- `POST /signup/api` returns 200 with every `steps` true; account joins
+  space + child rooms + creates inviter DM.
+- Knock with a valid code → invite to a *vetting* room (not the space).
+- Posting a valid 3-line haiku containing the wikipedia keyword → invite
+  to the space.
+- Knock with a bogus code → no invites at all.
+
+Designed to also run against prod by setting `HOMESERVER` + the env vars
+in `tests/README.md` of yore. Inside the CI stack `run_in_runner.sh`
+points it at the in-network landing nginx.
+
+### `vetting_e2e.py` — real E2EE round-trip of the vetting flow
+
+Two `mautrix-python` clients with `OlmMachine` + `PgCryptoStore`. Two
+fresh users each:
+
+1. Knock the space with a valid code.
+2. Land in a per-knock vetting room.
+3. Solve the haiku captcha.
+4. Get promoted to the space + auto-join the encrypted `#bot-noise` child.
+
+Then user A sends an encrypted message in `#bot-noise`, user B's
+OlmMachine decrypts it. **This** is the actual E2EE assertion — a
+megolm round-trip between two independently-onboarded users that
+proves the new vetting flow doesn't wedge crypto.
+
+### `sas_e2e.py` — Paste A+B+C SAS verification (informational)
+
+Pre-existing test. Boots `landing/responder.py` and an initiator-side
+`_SASInitiator`, runs the full SAS dance, asserts the verifier's
+`PgCryptoStore` flips the bot's device to `TrustState.VERIFIED`.
+
+**Run as informational, not as a gate** — the SAS dance against
+continuwuity is known-flaky (tracked in issue #1) and we don't want to
+block PR merges on it. `run_in_runner.sh` runs it and reports the
+outcome but a failure does not fail the run. Tighten this once SAS is
+stable.
+
+Together these three tests cover the things a PR could plausibly
+break in this repo:
+
+| Test             | Gates? | Breaks if you break...                                |
+|------------------|--------|-------------------------------------------------------|
+| `smoke.py`       | YES    | the HTTP signup/knock/vetting flow                    |
+| `vetting_e2e.py` | YES    | E2EE megolm correctness for a freshly-onboarded user |
+| `sas_e2e.py`     | no     | the Paste A+B+C SAS verification chain                |
+
+## Running everything (the PR gate)
 
 ```bash
-ADMIN_TOKEN=<shape-rotator-2 token> \
-REG_TOKEN=<continuwuity reg token> \
-SIGNUP_CODE=<a code with uses remaining> \
-KNOCK_CODE=<a knock code with uses remaining> \
-  python3 tests/smoke.py
+bash tests/run_e2e.sh
 ```
 
-### Against local dev stack
+That wrapper:
+
+1. Brings up `continuwuity` alone, polls its logs for the one-time
+   bootstrap registration token continuwuity prints on first boot
+   (`docker compose logs ... | grep ...`).
+2. Brings up the rest of the stack (`bootstrap`, `knock-approver`,
+   `landing`, `test-runner`) with that token in env.
+3. The `bootstrap` container creates the admin user, space, child
+   rooms, and codes; writes `/shared/test.env`.
+4. `knock-approver` and `test-runner` source that env file at startup.
+5. `test-runner` runs `smoke.py`, `vetting_e2e.py`, `sas_e2e.py`
+   sequentially.
+6. Stack is torn down with `down -v` on exit (clean run every time).
+
+CI calls this same script from `.github/workflows/test.yml`.
+
+## Running one test against the dev stack (faster iteration)
 
 ```bash
+cd dev && docker compose up -d && cd ..
 eval "$(python3 dev/bootstrap.py)"
-# (start approver in another shell first, with HTTP_PORT set)
-
+# In another shell, start the approver:
+HTTP_PORT=18001 python3 knock-approver/approver.py
+# Run a single test:
 HOMESERVER=http://localhost:46167 \
   ADMIN_TOKEN=$MATRIX_TOKEN \
   REG_TOKEN=$CONDUWUIT_REGISTRATION_TOKEN \
-  SIGNUP_CODE=$DEV_SIGNUP_CODE \
-  KNOCK_CODE=$DEV_KNOCK_CODE \
-  SPACE_ID=$SPACE_ID \
-  SPACE_CHILDREN=$SPACE_CHILD_IDS \
+  SIGNUP_CODE=$DEV_SIGNUP_CODE KNOCK_CODE=$DEV_KNOCK_CODE \
+  SPACE_ID=$SPACE_ID SPACE_CHILDREN=$SPACE_CHILD_IDS \
   python3 tests/smoke.py
 ```
 
-Exit code 0 = all checks passed. Any failure prints the specific line that
-didn't match plus the server's response so the cause is obvious.
+The dev path skips `landing/`'s nginx — `/signup/api` won't be reachable
+on the bare continuwuity port, so the `smoke.py` signup checks will
+fail there. Use `tests/run_e2e.sh` for the full picture.
+
+## Running against prod
+
+`tests/sas_prod.py` runs the SAS-verification subset against
+`mtrx.shaperotator.xyz` for spot-checking a deploy:
+
+```bash
+SIGNUP_CODE=... ADMIN_TOKEN=... python3 tests/sas_prod.py
+```
+
+This is **not** part of the PR gate — production is out-of-band.
+
+## Files
+
+- `Dockerfile` — test-runner image (libolm + mautrix + nio + cryptography).
+- `docker-compose.test.yml` — full stack used by the PR gate.
+- `run_e2e.sh` — host-side wrapper that handles the bootstrap-token dance.
+- `run_in_runner.sh` — runs inside the test-runner; sources env, runs
+  every test in sequence.
+- `smoke.py`, `vetting_e2e.py`, `sas_e2e.py`, `sas_prod.py` — the tests.

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,0 +1,122 @@
+# Full e2e stack for PR-gating tests.
+#
+# Use via tests/run_e2e.sh — that wrapper handles the one-time
+# bootstrap-token dance continuwuity does on first boot, then drives
+# this file with --abort-on-container-exit --exit-code-from test-runner.
+#
+# Layout:
+#   continuwuity   — homeserver
+#   bootstrap      — oneshot, creates admin/space/child rooms/codes,
+#                    writes /shared/test.env for the rest of the stack
+#   knock-approver — waits for /shared/test.env, runs approver.py
+#                    (exact same script that ships to prod, bind-mounted)
+#   landing        — nginx with the production nginx.conf, bind-mounted
+#                    landing pages and proxy rules
+#   test-runner    — runs every test; exit code is the gate
+services:
+  continuwuity:
+    image: ghcr.io/continuwuity/continuwuity:latest
+    environment:
+      CONDUWUIT_SERVER_NAME: "localhost:46167"
+      CONDUWUIT_DATABASE_BACKEND: rocksdb
+      CONDUWUIT_DATABASE_PATH: /var/lib/conduwuit
+      CONDUWUIT_ADDRESS: "0.0.0.0"
+      CONDUWUIT_PORT: "6167"
+      CONDUWUIT_ALLOW_REGISTRATION: "true"
+      CONDUWUIT_REGISTRATION_TOKEN: "test-token"
+      CONDUWUIT_ALLOW_FEDERATION: "false"
+      CONDUWUIT_LOG: info
+    volumes:
+      - continuwuity-test-data:/var/lib/conduwuit
+
+  bootstrap:
+    build: .
+    depends_on:
+      - continuwuity
+    environment:
+      DEV_HS: http://continuwuity:6167
+      CONDUWUIT_BOOTSTRAP_TOKEN: ${CONDUWUIT_BOOTSTRAP_TOKEN}
+      CONDUWUIT_REGISTRATION_TOKEN: "test-token"
+      DEV_STATE_PATH: /shared/dev-state.json
+    volumes:
+      - ..:/repo
+      - shared:/shared
+    working_dir: /repo
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        echo "[bootstrap] waiting for continuwuity"
+        for i in $$(seq 1 60); do
+          if curl -fsS http://continuwuity:6167/_matrix/client/versions >/dev/null 2>&1; then break; fi
+          sleep 1
+        done
+        echo "[bootstrap] running dev/bootstrap.py"
+        python3 dev/bootstrap.py > /shared/test.env
+        echo "[bootstrap] wrote /shared/test.env:"
+        grep -v '^#' /shared/test.env | sed 's/=.*/=<redacted>/'
+
+  knock-approver:
+    image: python:3.11-slim
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    volumes:
+      - ../knock-approver/approver.py:/app.py:ro
+      - shared:/shared
+      - knock-test-data:/data
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        echo "[approver] sourcing /shared/test.env"
+        set -a
+        . /shared/test.env
+        set +a
+        # Inside the docker network the approver speaks directly to continuwuity,
+        # not through nginx. Override HS and HS_PUBLIC accordingly.
+        export HS=http://continuwuity:6167
+        export HS_PUBLIC=http://landing:80
+        # Tighter vetting timeout for faster CI: stale rooms reaped in 5 minutes
+        # rather than 2 hours.
+        export VETTING_TIMEOUT_SEC=300
+        export HTTP_PORT=8001
+        pip install --quiet aiohttp cryptography
+        exec python -u /app.py
+
+  landing:
+    image: nginx:alpine
+    depends_on:
+      - continuwuity
+      - knock-approver
+    volumes:
+      - ../landing/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../landing/index.html:/usr/share/nginx/html/index.html:ro
+      - ../landing/join.html:/usr/share/nginx/html/join.html:ro
+      - ../landing/signup.html:/usr/share/nginx/html/signup.html:ro
+      - ../landing/responder.py:/usr/share/nginx/html/responder.py:ro
+      - ../landing/sas_verification.py:/usr/share/nginx/html/sas_verification.py:ro
+
+  test-runner:
+    build: .
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+      knock-approver:
+        condition: service_started
+      landing:
+        condition: service_started
+    environment:
+      HS: http://landing:80
+    volumes:
+      - ..:/repo
+      - shared:/shared
+    working_dir: /repo
+    command: ["bash", "tests/run_in_runner.sh"]
+
+volumes:
+  continuwuity-test-data:
+  knock-test-data:
+  shared:

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Host-side wrapper that runs the full e2e stack.
+#
+# What it does:
+#   1. Brings up continuwuity by itself.
+#   2. Polls the container logs for the one-time bootstrap registration
+#      token continuwuity prints on first boot.
+#   3. Brings up the rest of the stack with that token in env, so the
+#      bootstrap container (which has no docker-socket access) can use it.
+#   4. Streams logs and exits with the test-runner's exit code.
+#
+# CI runs this. Dev can also run it: `bash tests/run_e2e.sh`.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+COMPOSE=(docker compose -f docker-compose.test.yml -p shape-rotator-e2e)
+
+cleanup() {
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "[run_e2e] FAIL — capturing service logs before teardown" >&2
+    for svc in continuwuity bootstrap knock-approver landing; do
+      echo "=== $svc ===" >&2
+      "${COMPOSE[@]}" logs --no-color --tail=100 "$svc" >&2 2>&1 || true
+    done
+  fi
+  echo "[run_e2e] tearing down stack" >&2
+  "${COMPOSE[@]}" down -v --remove-orphans >&2 || true
+}
+trap cleanup EXIT
+
+# Fresh start so the bootstrap-token dance is reproducible.
+"${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+
+echo "[run_e2e] starting continuwuity" >&2
+"${COMPOSE[@]}" up -d --build continuwuity
+
+echo "[run_e2e] waiting for bootstrap token to appear in continuwuity logs" >&2
+TOKEN=""
+for i in $(seq 1 60); do
+  # continuwuity wraps the token in ANSI color codes even when --no-color is
+  # passed (the codes come from the container's own output, not compose).
+  # Strip them with sed before grepping.
+  TOKEN=$(
+    "${COMPOSE[@]}" logs --no-color continuwuity 2>&1 \
+      | sed -E 's/\x1b\[[0-9;]*m//g' \
+      | grep -oE 'using the registration token [A-Za-z0-9]+' \
+      | awk '{print $NF}' \
+      | head -n1 \
+      || true
+  )
+  if [ -n "$TOKEN" ]; then break; fi
+  sleep 1
+done
+if [ -z "$TOKEN" ]; then
+  echo "[run_e2e] FAIL: never saw a bootstrap token. Recent logs:" >&2
+  "${COMPOSE[@]}" logs --tail=80 continuwuity >&2 || true
+  exit 1
+fi
+echo "[run_e2e] bootstrap token: $TOKEN" >&2
+
+export CONDUWUIT_BOOTSTRAP_TOKEN="$TOKEN"
+
+echo "[run_e2e] building all images" >&2
+"${COMPOSE[@]}" build
+
+echo "[run_e2e] bringing up bootstrap + approver + landing" >&2
+# `up -d` blocks here until bootstrap exits successfully, because
+# knock-approver depends_on bootstrap with service_completed_successfully.
+# If bootstrap fails, `up -d` returns nonzero and we exit.
+if ! "${COMPOSE[@]}" up -d bootstrap knock-approver landing; then
+  echo "[run_e2e] FAIL: bring-up failed" >&2
+  "${COMPOSE[@]}" logs --tail=80 bootstrap >&2 || true
+  exit 1
+fi
+
+echo "[run_e2e] running test-runner" >&2
+# `run --rm` blocks foreground, returns the runner's own exit code, and
+# leaves the rest of the stack up so logs from a failure are inspectable.
+"${COMPOSE[@]}" run --rm test-runner bash tests/run_in_runner.sh

--- a/tests/run_in_runner.sh
+++ b/tests/run_in_runner.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Runs INSIDE the test-runner container. Source the env file the bootstrap
+# container wrote, wait for the approver to be live, run every test, exit
+# nonzero on the first failure.
+set -euo pipefail
+
+ENV_FILE=/shared/test.env
+APPROVER=http://knock-approver:8001
+
+echo "[runner] sourcing $ENV_FILE"
+test -f "$ENV_FILE" || { echo "[runner] FAIL: $ENV_FILE not produced by bootstrap"; exit 1; }
+set -a
+. "$ENV_FILE"
+set +a
+# bootstrap.py exports HS pointing at continuwuity directly (that's what the
+# approver wants); the runner instead must exercise the same entry point real
+# clients hit, which is the landing nginx in front of everything. Override
+# after sourcing.
+export HS=http://landing:80
+export HOMESERVER=$HS
+
+echo "[runner] waiting for approver health"
+for i in $(seq 1 60); do
+  if curl -fsS "$APPROVER/health" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+curl -fsS "$APPROVER/health" >/dev/null
+
+echo "[runner] env summary:"
+echo "  HS=$HS"
+echo "  SPACE_ID=$SPACE_ID"
+echo "  SPACE_CHILD_IDS=$SPACE_CHILD_IDS"
+echo "  ADMIN_MXID=$ADMIN_MXID"
+
+# stdlib flow test (signup + knock-vetting). Uses landing nginx as HS so it
+# hits both the matrix endpoints AND /signup/api in one shot.
+echo "[runner] === smoke.py ==="
+ADMIN_TOKEN="$ADMIN_TOKEN" \
+  REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+  SIGNUP_CODE="$DEV_SIGNUP_CODE" \
+  KNOCK_CODE="$DEV_KNOCK_CODE" \
+  SPACE_ID="$SPACE_ID" \
+  SPACE_CHILDREN="$SPACE_CHILD_IDS" \
+  HOMESERVER="$HS" \
+  python3 tests/smoke.py
+
+# Real E2EE round-trip test of the new vetting flow.
+echo "[runner] === vetting_e2e.py ==="
+DEV_HS="$HS" \
+  DEV_REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+  DEV_KNOCK_CODE="$DEV_KNOCK_CODE" \
+  DEV_SIGNUP_CODE="$DEV_SIGNUP_CODE" \
+  SPACE_ID="$SPACE_ID" \
+  SPACE_CHILD_IDS="$SPACE_CHILD_IDS" \
+  ADMIN_MXID="$ADMIN_MXID" \
+  python3 tests/vetting_e2e.py
+
+# Paste A+B+C SAS verification end-to-end. **Informational**: the
+# upstream SAS dance is tracked-flaky against continuwuity (issue #1) so
+# we run the test for visibility but don't gate the PR on its outcome.
+# The vetting flow's E2EE round-trip (above) is the real megolm gate.
+echo "[runner] === sas_e2e.py === (informational; failures don't gate the PR)"
+if DEV_HS="$HS" \
+     DEV_REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+     DEV_SIGNUP_CODE="$DEV_SIGNUP_CODE" \
+     python3 tests/sas_e2e.py; then
+  echo "[runner] sas_e2e: PASS"
+else
+  echo "[runner] sas_e2e: FAIL (informational — see issue #1)"
+fi
+
+echo "[runner] all gating tests passed"

--- a/tests/vetting_e2e.py
+++ b/tests/vetting_e2e.py
@@ -1,0 +1,236 @@
+"""End-to-end test of the per-knock vetting flow + an actual E2EE round-trip.
+
+What it asserts:
+  1. A fresh user can knock with a valid code and gets invited to a NEW room
+     that is NOT the space (the per-knock vetting room).
+  2. The bot's welcome message in the vetting room contains a `keyword`.
+  3. Replying with a valid 3-line haiku containing that keyword causes the
+     approver to invite the user to the space.
+  4. The user accepts and auto-joins the E2EE child room (`#bot-noise`).
+  5. A SECOND fresh user joins via the same flow and ends up in the same
+     E2EE room.
+  6. User #1 sends an encrypted message in the room; user #2's OlmMachine
+     decrypts it. This is the actual E2EE assertion — a megolm round-trip
+     between two independently-onboarded users that proves the flow doesn't
+     wedge crypto.
+
+Run inside the test-runner container — `tests/run_e2e.sh` is the entry
+point, and that's what CI calls.
+
+Env (all pre-set by run_in_runner.sh):
+  DEV_HS              homeserver URL
+  DEV_REG_TOKEN       continuwuity registration token
+  DEV_KNOCK_CODE      a knock code with >= 2 uses
+  SPACE_ID            unsuffixed space room id
+  SPACE_CHILD_IDS     comma-separated child room IDs (general, announcements, bot-noise)
+"""
+import asyncio, json, os, re, secrets, sys, time, urllib.error, urllib.parse, urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tests"))
+
+from sas_e2e import make_client, sync_once, register
+
+from mautrix.types import (EventType, MessageType, TextMessageEventContent,
+                           UserID)
+
+HS              = os.environ.get("DEV_HS", "http://landing:80").rstrip("/")
+REG_TOKEN       = os.environ["DEV_REG_TOKEN"]
+KNOCK_CODE      = os.environ["DEV_KNOCK_CODE"]
+SPACE_ID        = os.environ["SPACE_ID"]
+SPACE_CHILD_IDS = [c.strip() for c in os.environ["SPACE_CHILD_IDS"].split(",") if c.strip()]
+# bot-noise is the canonical E2EE child room (third in the bootstrap order).
+ENC_ROOM = SPACE_CHILD_IDS[-1] if SPACE_CHILD_IDS else None
+
+results = []
+def log(name, ok, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {name}" + (f"  ({detail})" if detail else ""), flush=True)
+    results.append((name, ok))
+
+
+def http(method, path, token=None, body=None, timeout=15):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{HS}{path}", data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        try:    return e.code, json.loads(e.read() or b"{}")
+        except: return e.code, {}
+
+
+async def onboard_via_vetting(label):
+    """Register, set displayname, knock, complete vetting, end up in space."""
+    username = f"e2e_{label}_{int(time.time())}_{secrets.token_hex(2)}"
+    device   = f"E2E{label.upper()}{secrets.token_hex(2)}"
+    mxid, token = register(username, secrets.token_urlsafe(32), device)
+    print(f"[{label}] registered {mxid} device={device}", flush=True)
+
+    http("PUT",
+         f"/_matrix/client/v3/profile/{urllib.parse.quote(mxid)}/displayname",
+         token=token, body={"displayname": f"e2e-{label}"})
+
+    s, _ = http("POST",
+                f"/_matrix/client/v3/knock/{urllib.parse.quote(SPACE_ID)}",
+                token=token, body={"reason": KNOCK_CODE})
+    log(f"[{label}] knock posted", s == 200, f"status={s}")
+
+    space_prefix = SPACE_ID.split(":")[0]
+    deadline = time.time() + 30
+    vetting_room = None
+    while time.time() < deadline:
+        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        for rid in sync.get("rooms", {}).get("invite", {}).keys():
+            if rid.split(":")[0] != space_prefix:
+                vetting_room = rid
+                break
+        if vetting_room:
+            break
+        await asyncio.sleep(1)
+    log(f"[{label}] vetting room invite arrived", bool(vetting_room),
+        f"room={vetting_room}")
+    if not vetting_room:
+        return None
+
+    s, _ = http("POST",
+                f"/_matrix/client/v3/join/{urllib.parse.quote(vetting_room)}",
+                token=token, body={})
+    log(f"[{label}] joined vetting room", s == 200, f"status={s}")
+
+    # Pull the captcha challenge — bot may need a beat after our join.
+    keyword = None
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        joined = sync.get("rooms", {}).get("join", {}).get(vetting_room, {})
+        for ev in joined.get("timeline", {}).get("events", []):
+            if ev.get("type") != "m.room.message":
+                continue
+            body = (ev.get("content") or {}).get("body", "")
+            m = re.search(r'include the word "([^"]+)"', body)
+            if m:
+                keyword = m.group(1)
+                break
+        if keyword:
+            break
+        await asyncio.sleep(1)
+    log(f"[{label}] captcha keyword visible", bool(keyword), f"keyword={keyword!r}")
+    if not keyword:
+        return None
+
+    haiku = (f"silent {keyword} hum\n"
+             f"floating in the morning fog\n"
+             f"spring wind blowing through")
+    s, _ = http(
+        "PUT",
+        f"/_matrix/client/v3/rooms/{urllib.parse.quote(vetting_room)}"
+        f"/send/m.room.message/e2e-haiku-{label}-{int(time.time())}",
+        token=token, body={"msgtype": "m.text", "body": haiku})
+    log(f"[{label}] haiku sent", s == 200, f"status={s}")
+
+    # Wait for the actual space invite.
+    deadline = time.time() + 30
+    got_space = False
+    while time.time() < deadline:
+        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        if any(rid.split(":")[0] == space_prefix
+               for rid in sync.get("rooms", {}).get("invite", {}).keys()):
+            got_space = True
+            break
+        await asyncio.sleep(1)
+    log(f"[{label}] space invite after vetting", got_space)
+    if not got_space:
+        return None
+
+    s, _ = http("POST",
+                f"/_matrix/client/v3/rooms/{urllib.parse.quote(SPACE_ID)}/join",
+                token=token, body={})
+    log(f"[{label}] accepted space invite", s == 200, f"status={s}")
+
+    # Restricted child rooms — user can self-join now.
+    for child in SPACE_CHILD_IDS:
+        http("POST",
+             f"/_matrix/client/v3/rooms/{urllib.parse.quote(child)}/join",
+             token=token, body={})
+
+    return mxid, token, device
+
+
+async def main():
+    if not SPACE_CHILD_IDS:
+        print("no SPACE_CHILD_IDS — cannot run E2EE round-trip portion", file=sys.stderr)
+        sys.exit(2)
+
+    # Onboard two independent users via the vetting flow.
+    a = await onboard_via_vetting("alice")
+    b = await onboard_via_vetting("bob")
+    if not a or not b:
+        print("onboarding failed; skipping E2EE round-trip")
+        sys.exit(1)
+    a_mxid, a_token, a_device = a
+    b_mxid, b_token, b_device = b
+
+    # Spin up two real mautrix clients with OlmMachine + crypto store.
+    a_client, a_cs, a_ss, a_db = await make_client(
+        a_mxid, a_token, a_device, db_path=f"/tmp/{secrets.token_hex(4)}_a.db")
+    b_client, b_cs, b_ss, b_db = await make_client(
+        b_mxid, b_token, b_device, db_path=f"/tmp/{secrets.token_hex(4)}_b.db")
+    await a_client.crypto.share_keys()
+    await b_client.crypto.share_keys()
+
+    # Initial syncs so each one sees they're in the encrypted child room and
+    # the other's device keys land in their crypto store.
+    for _ in range(3):
+        await sync_once(a_client, a_ss, timeout=2000, first=True)
+        await sync_once(b_client, b_ss, timeout=2000, first=True)
+
+    # Confirm the room is actually encrypted from each side.
+    a_enc = await a_ss.is_encrypted(ENC_ROOM)
+    b_enc = await b_ss.is_encrypted(ENC_ROOM)
+    log("E2EE child room reports encrypted (alice side)", bool(a_enc))
+    log("E2EE child room reports encrypted (bob side)",   bool(b_enc))
+
+    # Alice sends an encrypted message; Bob decrypts.
+    secret = f"vetting-e2e secret {secrets.token_hex(8)}"
+    event_id = await a_client.send_message_event(
+        ENC_ROOM, EventType.ROOM_MESSAGE,
+        TextMessageEventContent(msgtype=MessageType.TEXT, body=secret))
+    log("alice sent encrypted message", bool(event_id),
+        f"event_id={event_id}")
+
+    decrypted_body = None
+    deadline = time.time() + 30
+    received = asyncio.Event()
+
+    async def on_msg(evt):
+        nonlocal decrypted_body
+        if evt.room_id != ENC_ROOM or evt.sender == b_mxid:
+            return
+        body = getattr(evt.content, "body", "") or ""
+        if body == secret:
+            decrypted_body = body
+            received.set()
+
+    b_client.add_event_handler(EventType.ROOM_MESSAGE, on_msg)
+    while time.time() < deadline and not received.is_set():
+        await sync_once(b_client, b_ss, timeout=2000)
+    log("bob decrypted alice's message via OlmMachine",
+        decrypted_body == secret, f"got={decrypted_body!r}")
+
+    await a_db.stop()
+    await b_db.stop()
+
+    failed = [name for name, ok in results if not ok]
+    print(f"\n=== {len(results) - len(failed)}/{len(results)} pass ===")
+    if failed:
+        print("FAILED: " + ", ".join(failed), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Stacked on #4. Build a full containerized PR-gating harness and an auto-deploy workflow, so we can't merge anything that breaks the bot stories without it being obvious in CI.

## Summary

- `tests/Dockerfile` — runner image (libolm + mautrix + nio + cryptography + curl).
- `tests/docker-compose.test.yml` — full stack (continuwuity + landing nginx + knock-approver + bootstrap + test-runner). Bind-mounts repo source so a code change is a fast restart, not a rebuild.
- `tests/run_e2e.sh` — host-side wrapper. Brings continuwuity up alone, scrapes the one-time bootstrap registration token from its logs (handling the ANSI color codes continuwuity emits), then brings up the rest of the stack with that token in env, runs every test, returns the gating exit code. Captures service logs on failure.
- `tests/run_in_runner.sh` — runs inside the test-runner; sources the env the bootstrap container wrote, runs each test in sequence.
- **`tests/vetting_e2e.py`** (new) — real E2EE round-trip test of the vetting flow. Two `mautrix-python` clients with `OlmMachine` + `PgCryptoStore`. Both knock with valid codes, solve the haiku captcha, get promoted into the encrypted `#bot-noise` child room. User A sends an encrypted message; user B's `OlmMachine` decrypts it. Asserts on the actual megolm round-trip — proves the new vetting flow doesn't wedge crypto.
- `.github/workflows/test.yml` — runs `bash tests/run_e2e.sh` on every PR + push to main; also exposes `workflow_call` so the deploy workflow can re-use it as a gate.
- `.github/workflows/deploy.yml` — **auto-deploys mtrx.shaperotator.xyz** on every merge to main, gated on the e2e workflow. Rebuilds .env from gh secrets, runs `deploy/encode_env.sh`, runs `phala deploy --cvm-id dstack-matrix`. Required secrets documented in the workflow.

| Test | Gates? | Breaks if you break... |
|---|---|---|
| `smoke.py` | yes | the HTTP signup/knock/vetting flow |
| `vetting_e2e.py` | yes | E2EE megolm correctness for a freshly-onboarded user |
| `sas_e2e.py` | no (informational) | the Paste A+B+C SAS verification chain (tracked-flaky in #1) |

## Drive-by bug fixes uncovered by the harness

- **`knock-approver/approver.py`**: `process_vetting_room` required both the user's join event AND messages in the same `/sync` batch. Continuwuity splits those across cycles, so promotion never fired (smoke went 17/18 with `[FAIL] space invite after vetting`). Now persists displayname into vetting state on first observed join.
- **`dev/bootstrap.py`**: was setting `INITIAL_CODES = INITIAL_SIGNUP_CODES` (same seed for both). Knock seed now goes to `INITIAL_CODES`. Also exports `ADMIN_TOKEN`/`ADMIN_MXID` and accepts `CONDUWUIT_BOOTSTRAP_TOKEN` env so the bootstrap container can run without docker-socket access.

## How to run locally

```bash
bash tests/run_e2e.sh
```

About 3-5 minutes from cold (libolm + mautrix install in the runner image build); ~30s on a warm cache. Final output:

```
[runner] === smoke.py ===
=== 18/18 passed ===
[runner] === vetting_e2e.py ===
[PASS] alice sent encrypted message
[PASS] bob decrypted alice's message via OlmMachine
=== 18/18 pass ===
[runner] === sas_e2e.py === (informational)
[runner] sas_e2e: PASS
[runner] all gating tests passed
```

## Deploy workflow

The auto-deploy reads from these gh secrets (set under Settings → Secrets and variables → Actions):

- `PHALA_API_KEY` — phala CLI api token
- `NAMECHEAP_USERNAME`, `NAMECHEAP_API_KEY` — DNS-01 LE creds
- `REGISTRATION_TOKEN` — continuwuity registration token
- `KNOCK_APPROVER_TOKEN` — access token of `@shape-rotator-2`
- `DSTACK_AUTHORIZED_KEYS` — ssh authorized_keys for the CVM
- `ONBOARDING_INVITER_MXID`, `SHAPEROTATOR_SPACE_ID`, `SPACE_CHILD_IDS`
- `INITIAL_CODES`, `INITIAL_SIGNUP_CODES` — JSON, can be `{}`

Once those are set, every push to main triggers a deploy if the e2e gate is green. `workflow_dispatch` is also wired up for out-of-band redeploys (rotating a secret, emergency push).

## Test plan

- [x] Local: `bash tests/run_e2e.sh` exits 0 with all gating tests green.
- [x] Vetting flow exercised by two independent users; megolm round-trip in `#bot-noise` decrypts correctly.
- [ ] CI run on this PR (turning on once Account-Link gh secrets are populated).
- [ ] First deploy on merge — verify the cvm picks up the new approver code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)