### PR TITLE
deploy.yml: actually pipe ADMIN_COMMAND_ROOM into .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
           INITIAL_CODES: ${{ secrets.INITIAL_CODES }}
           INITIAL_SIGNUP_CODES: ${{ secrets.INITIAL_SIGNUP_CODES }}
           ADMIN_ALLOWLIST: ${{ secrets.ADMIN_ALLOWLIST }}
+          ADMIN_COMMAND_ROOM: ${{ secrets.ADMIN_COMMAND_ROOM }}
         run: |
           {
             echo "NAMECHEAP_USERNAME=$NAMECHEAP_USERNAME"
@@ -75,6 +76,7 @@ jobs:
             echo "INITIAL_CODES=$INITIAL_CODES"
             echo "INITIAL_SIGNUP_CODES=$INITIAL_SIGNUP_CODES"
             echo "ADMIN_ALLOWLIST=$ADMIN_ALLOWLIST"
+            echo "ADMIN_COMMAND_ROOM=$ADMIN_COMMAND_ROOM"
           } > .env
           bash deploy/encode_env.sh
 


### PR DESCRIPTION
Bug uncovered by the post-deploy log on the run from #11:

```
[startup] ... admin room=!4FL8...; allowlist=[...]   ← space id, not the new devops room id
```

I'd plumbed `ADMIN_COMMAND_ROOM` through `docker-compose.yml` (`\${ADMIN_COMMAND_ROOM:-}`) but forgot to also include it in the `build .env` step of the deploy workflow. So the GH secret was set, the compose substitution worked, but the `.env` that `phala deploy` seals into the CVM had no `ADMIN_COMMAND_ROOM=` line — falls back to empty, then in-code falls back to `SPACE_ID`. Bot kept listening in the wrong room.

One-line fix: add the var to both the `env:` block and the heredoc.

Once this merges and a new deploy fires, the approver startup line should read `admin room=!amfRBsR...` — the actual `#matrix-devops` room id.