### PR TITLE
🔻 going-down message + downtime in success post

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,6 +137,27 @@ jobs:
           echo "[delay] heads-up posted; sleeping ${DELAY}s before phala deploy"
           sleep "$DELAY"
 
+      - name: going-down notice
+        env:
+          KNOCK_APPROVER_TOKEN: ${{ secrets.KNOCK_APPROVER_TOKEN }}
+          ADMIN_COMMAND_ROOM: ${{ secrets.ADMIN_COMMAND_ROOM }}
+          GH_RUN: ${{ github.run_id }}
+        run: |
+          # Posted right before the CVM goes down — explicit "outage
+          # starts now" signal. By this point the cancel window is closed.
+          # Also records the timestamp used to report downtime in the
+          # success message.
+          if [ -n "${ADMIN_COMMAND_ROOM:-}" ] && [ -n "${KNOCK_APPROVER_TOKEN:-}" ]; then
+            ROOM_ENC=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))" "$ADMIN_COMMAND_ROOM")
+            BODY=$(python3 -c "import json; print(json.dumps({'msgtype':'m.text','body':'🔻 restarting CVM now — mtrx.shaperotator.xyz briefly unreachable, back in ~2 min'}))")
+            curl -fsS -X PUT \
+              -H "Authorization: Bearer $KNOCK_APPROVER_TOKEN" \
+              -H 'Content-Type: application/json' \
+              "https://mtrx.shaperotator.xyz/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/predown-$GH_RUN" \
+              -d "$BODY"
+          fi
+          echo "DOWNTIME_START_TS=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: phala deploy
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_API_KEY }}
@@ -195,6 +216,9 @@ jobs:
             echo "::error::homeserver not returning 200 on /versions"
             exit 1
           fi
+          # Record recovery timestamp — used by the success-message step
+          # to report total downtime.
+          echo "DOWNTIME_END_TS=$(date +%s)" >> "$GITHUB_ENV"
           # Bot health: /whoami should return @shape-rotator-2.
           who=$(curl -sS -H "Authorization: Bearer $KNOCK_APPROVER_TOKEN" \
             https://mtrx.shaperotator.xyz/_matrix/client/v3/account/whoami \
@@ -224,7 +248,17 @@ jobs:
           sha = os.environ.get("GH_SHA", "")[:7]
           msg = os.environ.get("GH_MSG", "(no commit message)")
           run = os.environ.get("GH_RUN", "")
-          body = f"🚀 deployed {sha} to dstack-matrix\n\n{msg}\n\nrun: https://github.com/Account-Link/shape-rotator-matrix/actions/runs/{run}"
+          start = os.environ.get("DOWNTIME_START_TS", "")
+          end = os.environ.get("DOWNTIME_END_TS", "")
+          downtime = ""
+          if start and end:
+              try:
+                  d = int(end) - int(start)
+                  if d >= 0:
+                      downtime = f"\ndowntime: ~{d}s"
+              except ValueError:
+                  pass
+          body = f"🚀 deployed {sha} to dstack-matrix{downtime}\n\n{msg}\n\nrun: https://github.com/Account-Link/shape-rotator-matrix/actions/runs/{run}"
           print(json.dumps({"msgtype": "m.text", "body": body}))
           PY
           )


### PR DESCRIPTION
Two visibility adds for the deploy flow, both in one PR since they're tightly related:

## 1. New step: "going-down notice"

Runs immediately before `phala deploy` (i.e. after the 10-min countdown). Posts to `ADMIN_COMMAND_ROOM`:

> 🔻 restarting CVM now — mtrx.shaperotator.xyz briefly unreachable, back in ~2 min

Why: the heads-up post says "in 10 min" but there's no signal at the moment the actual restart fires. Anyone watching #matrix-devops who reads the heads-up but then forgets — they'd see SSL handshake failures on mtrx without knowing why. The 🔻 message removes the gap. Also sets `DOWNTIME_START_TS` in `$GITHUB_ENV`.

## 2. Downtime field in success post

Health check step now also writes `DOWNTIME_END_TS` to `$GITHUB_ENV` the moment `/versions` returns 200 again. Post-deploy note reads both timestamps:

```
🚀 deployed abc1234 to dstack-matrix
downtime: ~95s

<commit message>

run: ...
```

So now you can eyeball deploy-to-deploy whether Phala is being slow ("90s downtime, normal") vs hitting trouble ("420s downtime, getting close to the recovery branch").

## Three messages per deploy now

| When | Message |
|---|---|
| 10 min before | 🚧 deploying X in ~10 min — cancel: ‹link› |
| at restart | 🔻 restarting CVM now — back in ~2 min |
| after recovery | 🚀 deployed X — downtime: ~Xs |

Each carries distinct info: heads-up + cancel window / outage starts now / outage ended + how long.

Will land in v0.5 whenever you tag it.