### PR TITLE
deploy/admin/lockdown_hermes_agent.sh — require E2EE on shape-rotator hermes profile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,6 +137,27 @@ jobs:
           echo "[delay] heads-up posted; sleeping ${DELAY}s before phala deploy"
           sleep "$DELAY"
 
+      - name: going-down notice
+        env:
+          KNOCK_APPROVER_TOKEN: ${{ secrets.KNOCK_APPROVER_TOKEN }}
+          ADMIN_COMMAND_ROOM: ${{ secrets.ADMIN_COMMAND_ROOM }}
+          GH_RUN: ${{ github.run_id }}
+        run: |
+          # Posted right before the CVM goes down — explicit "outage
+          # starts now" signal. By this point the cancel window is closed.
+          # Also records the timestamp used to report downtime in the
+          # success message.
+          if [ -n "${ADMIN_COMMAND_ROOM:-}" ] && [ -n "${KNOCK_APPROVER_TOKEN:-}" ]; then
+            ROOM_ENC=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))" "$ADMIN_COMMAND_ROOM")
+            BODY=$(python3 -c "import json; print(json.dumps({'msgtype':'m.text','body':'🔻 restarting CVM now — mtrx.shaperotator.xyz briefly unreachable, back in ~2 min'}))")
+            curl -fsS -X PUT \
+              -H "Authorization: Bearer $KNOCK_APPROVER_TOKEN" \
+              -H 'Content-Type: application/json' \
+              "https://mtrx.shaperotator.xyz/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/predown-$GH_RUN" \
+              -d "$BODY"
+          fi
+          echo "DOWNTIME_START_TS=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: phala deploy
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_API_KEY }}
@@ -195,6 +216,9 @@ jobs:
             echo "::error::homeserver not returning 200 on /versions"
             exit 1
           fi
+          # Record recovery timestamp — used by the success-message step
+          # to report total downtime.
+          echo "DOWNTIME_END_TS=$(date +%s)" >> "$GITHUB_ENV"
           # Bot health: /whoami should return @shape-rotator-2.
           who=$(curl -sS -H "Authorization: Bearer $KNOCK_APPROVER_TOKEN" \
             https://mtrx.shaperotator.xyz/_matrix/client/v3/account/whoami \
@@ -224,7 +248,17 @@ jobs:
           sha = os.environ.get("GH_SHA", "")[:7]
           msg = os.environ.get("GH_MSG", "(no commit message)")
           run = os.environ.get("GH_RUN", "")
-          body = f"🚀 deployed {sha} to dstack-matrix\n\n{msg}\n\nrun: https://github.com/Account-Link/shape-rotator-matrix/actions/runs/{run}"
+          start = os.environ.get("DOWNTIME_START_TS", "")
+          end = os.environ.get("DOWNTIME_END_TS", "")
+          downtime = ""
+          if start and end:
+              try:
+                  d = int(end) - int(start)
+                  if d >= 0:
+                      downtime = f"\ndowntime: ~{d}s"
+              except ValueError:
+                  pass
+          body = f"🚀 deployed {sha} to dstack-matrix{downtime}\n\n{msg}\n\nrun: https://github.com/Account-Link/shape-rotator-matrix/actions/runs/{run}"
           print(json.dumps({"msgtype": "m.text", "body": body}))
           PY
           )

--- a/deploy/admin/lockdown_hermes_agent.sh
+++ b/deploy/admin/lockdown_hermes_agent.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Lock down the shape-rotator hermes profile so it refuses cleartext
+# inputs from anyone (including @socrates1024). The patch is already
+# in the hermes image — patch_matrix_require_e2ee.py wraps
+# _on_room_message so MATRIX_REQUIRE_ENCRYPTION=true refuses AND
+# auto-leaves non-E2EE rooms. We just have to set the env var.
+#
+# Default: read-only inspect (prints current state, no changes).
+# Set APPLY=1 to actually update + restart hermes container.
+#
+#   bash deploy/admin/lockdown_hermes_agent.sh           # inspect
+#   APPLY=1 bash deploy/admin/lockdown_hermes_agent.sh   # apply
+set -uo pipefail
+
+KEY=/home/amiller/projects/hermes-agent/deploy-notes/deploy_key
+APPLY="${APPLY:-0}"
+
+phala ssh hermes-staging -- -i "$KEY" APPLY="$APPLY" bash -s <<'REMOTE'
+set -uo pipefail
+APPLY=${APPLY:-0}
+PROFILE=/root/.hermes/profiles/shape-rotator
+ENV_FILE=$PROFILE/.env
+
+echo "=== current state ==="
+echo "profile dir: $PROFILE"
+docker ps --format '{{.Names}}\t{{.Status}}' | grep -i hermes || echo "(no hermes container?!)"
+
+echo
+echo "=== relevant env vars in $ENV_FILE ==="
+HERMES_CID=$(docker ps --format '{{.Names}}' | grep -E 'hermes' | head -n1)
+if [ -z "$HERMES_CID" ]; then
+  echo "FAIL: no running hermes container found" >&2
+  exit 1
+fi
+docker exec "$HERMES_CID" sh -c "
+  if [ ! -f '$ENV_FILE' ]; then
+    echo '  $ENV_FILE: MISSING'
+    exit 0
+  fi
+  for k in MATRIX_HOMESERVER MATRIX_USER_ID MATRIX_DEVICE_ID MATRIX_ENCRYPTION MATRIX_REQUIRE_ENCRYPTION MATRIX_ALLOWED_USERS MATRIX_REQUIRE_MENTION; do
+    line=\$(grep -E \"^\$k=\" '$ENV_FILE' || true)
+    if [ -z \"\$line\" ]; then
+      echo \"  \$k: (unset)\"
+    else
+      # Print key + length only, never the secret value (only show booleans)
+      val=\${line#*=}
+      if [ \"\$val\" = 'true' ] || [ \"\$val\" = 'false' ]; then
+        echo \"  \$line\"
+      else
+        echo \"  \$k=<\${#val} bytes>\"
+      fi
+    fi
+  done
+"
+
+if [ "$APPLY" != "1" ]; then
+  echo
+  echo "=== read-only mode — re-run with APPLY=1 to update ==="
+  exit 0
+fi
+
+echo
+echo "=== applying MATRIX_REQUIRE_ENCRYPTION=true (dedup any existing entries) ==="
+docker exec "$HERMES_CID" sh -c "
+  set -e
+  # Remove ALL existing lines (handles dupes), then append a single canonical one.
+  sed -i '/^MATRIX_REQUIRE_ENCRYPTION=/d' '$ENV_FILE'
+  echo 'MATRIX_REQUIRE_ENCRYPTION=true' >> '$ENV_FILE'
+  echo 'updated lines:'
+  grep -n '^MATRIX_REQUIRE_ENCRYPTION=' '$ENV_FILE'
+"
+
+echo
+echo "=== restarting hermes container so the new env takes effect ==="
+docker restart "$HERMES_CID"
+echo "restarted $HERMES_CID"
+
+echo
+echo "=== post-restart state ==="
+sleep 5
+docker ps --format '{{.Names}}\t{{.Status}}' | grep -i hermes
+docker exec "$HERMES_CID" grep '^MATRIX_REQUIRE_ENCRYPTION=' "$ENV_FILE" 2>/dev/null || echo "(could not re-read)"
+REMOTE


### PR DESCRIPTION
Fixes the most acute security gap from #20: the hermes shape-rotator agent was accepting CLEARTEXT DMs as instructions. With the agent's wide tool access (github, file system, web fetch, matrix admin), a compromised homeserver could have injected forged events from `@socrates1024:matrix.org` and the agent would have acted on them.

## What

Single script that:
1. Inspects current `MATRIX_REQUIRE_ENCRYPTION` setting in `/root/.hermes/profiles/shape-rotator/.env` on hermes-staging.
2. Default mode = read-only. `APPLY=1 bash deploy/admin/lockdown_hermes_agent.sh` to actually flip the bit + restart the hermes container.
3. Dedups any duplicate entries from prior redeploys.

## Already executed against prod

`MATRIX_REQUIRE_ENCRYPTION=false → true`, dstack-hermes-1 restarted cleanly. The patched `_on_room_message` (memory: `patch_matrix_require_e2ee.py`) now refuses + auto-leaves any cleartext room the agent is in.

## Verification

Find your existing DM with `@shape-rotator-2` in Element. If it's already E2EE (shield icon, not "no shield"), it keeps working. If for some reason it was cleartext, the agent leaves on the next message and you start a fresh E2EE DM.

## What this does NOT fix (continues in #20)

- **Sender-device cross-signing verification.** A compromised homeserver could still inject E2EE events using a forged device — would need to compromise the bot's crypto store first, but it's not impossible. Real fix: when an admin command arrives, look up sender's device, require it be cross-signed by your master key.
- **Knock-approver `!mint` flow.** Different process listening in cleartext `#matrix-devops`. Same threat class. Eventual fix: move knock-approver to a mautrix-based bot (issue #7) and enable E2EE on the admin room (or the new `#admin` room).

This PR is just the immediate stop-the-bleeding step on the larger-blast-radius surface (the agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)