### PR TITLE
knock-approver: migrate to mautrix for E2EE admin commands (#7)

### DIFF
--- a/dev/bootstrap.py
+++ b/dev/bootstrap.py
@@ -272,6 +272,11 @@ def main():
     # server's returned string; don't normalize.
     echo(f"export SPACE_ID={space_id!r}")
     echo(f"export SPACE_CHILD_IDS={','.join(child_ids)!r}")
+    # Designate the last (encrypted) child room as the admin command room
+    # for tests. The migrated mautrix-based bot decrypts admin commands
+    # there; admin_e2ee.py exercises that path.
+    if child_ids:
+        echo(f"export ADMIN_COMMAND_ROOM={child_ids[-1]!r}")
     echo(f"export CONDUWUIT_REGISTRATION_TOKEN={REG_TOKEN!r}")
     echo(f"export ONBOARDING_INVITER_MXID={admin_mxid!r}")
     echo(f"export INITIAL_CODES={knock_seed!r}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,9 +105,13 @@ services:
       - knock-data:/data
     # Exposed on the internal docker network only; nginx proxies /signup/api
     # to port 8001 of this service. No host port mapping.
+    # libolm + mautrix needed for the E2EE-aware sync loop and
+    # cross-signing helpers. apt-get + pip install take ~60s on first
+    # boot; subsequent boots reuse the apt + pip layer caches.
     command: >
       sh -c '
-      pip install --quiet aiohttp cryptography &&
+      apt-get update -qq && apt-get install -y --no-install-recommends -qq libolm3 libolm-dev gcc &&
+      pip install --quiet aiohttp cryptography mautrix asyncpg aiosqlite python-olm unpaddedbase64 base58 pyaes &&
       echo "$$APPROVER_B64" | base64 -d > /app.py &&
       exec python -u /app.py
       '

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -33,6 +33,27 @@ from aiohttp import web
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
+# mautrix is the E2EE-aware Matrix client. Keep the imports top-level so a
+# missing dep blows up at process start (with a clear traceback) rather
+# than mid-sync. The HTTP /signup/api endpoint also runs in this process
+# and uses raw aiohttp — those flows don't need mautrix.
+from mautrix.api import HTTPAPI as _MAU_HTTPAPI
+from mautrix.client import Client as _MAU_Client
+from mautrix.client.state_store import (
+    MemoryStateStore as _MAU_MemoryStateStore,
+    MemorySyncStore as _MAU_MemorySyncStore,
+)
+from mautrix.types import (
+    UserID as _MAU_UserID,
+    EventType as _MAU_EventType,
+    MessageType as _MAU_MessageType,
+    TextMessageEventContent as _MAU_TextContent,
+    TrustState as _MAU_TrustState,
+)
+from mautrix.crypto import OlmMachine as _MAU_OlmMachine
+from mautrix.crypto.store.asyncpg import PgCryptoStore as _MAU_PgCryptoStore
+from mautrix.util.async_db import Database as _MAU_Database
+
 HS            = os.environ["HS"].rstrip("/")
 # Public-facing URL returned to signup clients (the client needs to point Element
 # at the public name, not the internal docker hostname).
@@ -45,6 +66,9 @@ SIGNUP_PATH   = Path(os.environ.get("SIGNUP_CODES_PATH", "/data/signup_codes.jso
 LOG_PATH      = Path(os.environ.get("LOG_PATH",          "/data/log.jsonl"))
 SYNC_STATE    = Path(os.environ.get("SYNC_STATE",        "/data/sync_since.txt"))
 HTTP_PORT     = int(os.environ.get("HTTP_PORT", "8001"))
+# Bot's E2EE crypto store (megolm sessions, identity keys, peer device keys).
+# Lives on the same /data volume so it survives container restarts.
+CRYPTO_DB     = Path(os.environ.get("CRYPTO_DB", "/data/bot_crypto.db"))
 
 # Comma-separated list of space-child room IDs that a freshly-signed-up user
 # should auto-join via the restricted rule. Typically: general, announcements,
@@ -130,14 +154,13 @@ async def _fetch_wiki_challenge():
     return title, keyword
 
 
-async def _send_msg(session, room_id, text):
-    txn = f"m{int(time.time()*1000)}-{os.urandom(2).hex()}"
-    url = f"{HS}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn}"
-    async with session.put(url, json={"msgtype": "m.text", "body": text}) as r:
-        return r.status
+async def _send_msg(client, room_id, text):
+    """Send a plain text message. Auto-encrypts if room has m.room.encryption."""
+    content = _MAU_TextContent(msgtype=_MAU_MessageType.TEXT, body=text)
+    return await client.send_message_event(room_id, _MAU_EventType.ROOM_MESSAGE, content)
 
 
-async def _create_vetting_room(session, mxid):
+async def _create_vetting_room(client, mxid):
     body = {
         "preset": "private_chat",   # creator PL 100, invitee PL 0
         "invite": [mxid],
@@ -145,10 +168,11 @@ async def _create_vetting_room(session, mxid):
         "name":  f"shape-rotator vetting · {mxid}",
         "topic": "captcha airlock — answer the challenge to be invited to the space.",
     }
-    async with session.post(f"{HS}/_matrix/client/v3/createRoom", json=body) as r:
-        if r.status != 200:
-            return None, await r.text()
-        return (await r.json())["room_id"], None
+    try:
+        resp = await client.api.request("POST", "/_matrix/client/v3/createRoom", content=body)
+        return resp["room_id"], None
+    except Exception as e:
+        return None, str(e)[:300]
 
 
 def _vet(displayname, message, keyword):
@@ -165,14 +189,35 @@ def _vet(displayname, message, keyword):
     return True, "ok"
 
 
-async def _promote(session, mxid):
-    url = f"{HS}/_matrix/client/v3/rooms/{SPACE_ID}/invite"
-    async with session.post(url,
-                            json={"user_id": mxid, "reason": "vetted via airlock"}) as r:
-        return r.status, await r.text()
+async def _promote(client, mxid):
+    try:
+        await client.api.request("POST",
+            f"/_matrix/client/v3/rooms/{SPACE_ID}/invite",
+            content={"user_id": mxid, "reason": "vetted via airlock"})
+        return 200, ""
+    except Exception as e:
+        return getattr(e, "http_status", 500), str(e)[:300]
 
 
-async def handle_knock(session, room_id, user_id, reason):
+async def _kick(client, room_id, user_id, reason="auto"):
+    try:
+        await client.api.request("POST",
+            f"/_matrix/client/v3/rooms/{room_id}/kick",
+            content={"user_id": user_id, "reason": reason})
+    except Exception as e:
+        print(f"[kick failed] {user_id} from {room_id}: {e}", flush=True)
+
+
+async def _leave(client, room_id, reason="auto"):
+    try:
+        await client.api.request("POST",
+            f"/_matrix/client/v3/rooms/{room_id}/leave",
+            content={"reason": reason})
+    except Exception as e:
+        print(f"[leave failed] {room_id}: {e}", flush=True)
+
+
+async def handle_knock(client, room_id, user_id, reason):
     code = (reason or "").strip()
     codes = _load(CODES_PATH)
     entry = codes.get(code)
@@ -182,7 +227,7 @@ async def handle_knock(session, room_id, user_id, reason):
         return
 
     title, keyword = await _fetch_wiki_challenge()
-    vroom, err = await _create_vetting_room(session, user_id)
+    vroom, err = await _create_vetting_room(client, user_id)
     if not vroom:
         audit({"type": "vetting_room_failed", "user": user_id,
                "code": code, "err": (err or "")[:200]})
@@ -201,7 +246,7 @@ async def handle_knock(session, room_id, user_id, reason):
     }
     _save(VETTING_PATH, state)
 
-    await _send_msg(session, vroom,
+    await _send_msg(client, vroom,
         f"hi {user_id} — quick captcha to keep bots out of shape rotator.\n\n"
         f"write a 3-line haiku about: {title}\n"
         f"include the word \"{keyword}\" somewhere.\n"
@@ -245,7 +290,7 @@ def iter_vetting_rooms(rooms_data, vetting_state):
         yield room_id, meta, join_ev, msgs
 
 
-async def process_vetting_room(session, room_id, meta, join_ev, msgs):
+async def process_vetting_room(client, room_id, meta, join_ev, msgs):
     """Process new messages in one vetting room. Returns updated meta or None."""
     # Persist displayname the first time we see the user's join event — Matrix
     # /sync returns the join event in one batch and the user's later messages
@@ -260,16 +305,16 @@ async def process_vetting_room(session, room_id, meta, join_ev, msgs):
         text = (msg.get("content") or {}).get("body", "")
         ok, why = _vet(displayname, text, keyword)
         if ok:
-            st, body = await _promote(session, meta["mxid"])
+            st, body = await _promote(client, meta["mxid"])
             if st == 200:
                 meta["promoted"] = True
                 meta["promoted_at"] = time.time()
                 meta["displayname"] = displayname
-                await _send_msg(session, room_id,
+                await _send_msg(client, room_id,
                     "nice — invited you to shape rotator. you can leave this room.")
                 # Relay the captcha + haiku to FEED_ROOM so the rest of
                 # the community sees who joined and gets to enjoy their
-                # haiku. Uses raw HTTP so FEED_ROOM must be cleartext.
+                # haiku. send_message_event auto-encrypts if FEED_ROOM is E2EE.
                 if FEED_ROOM:
                     haiku_lines = [f"> {l}" for l in (text or "").strip().splitlines() if l.strip()]
                     relay = "\n".join([
@@ -278,7 +323,7 @@ async def process_vetting_room(session, room_id, meta, join_ev, msgs):
                         "",
                         *haiku_lines,
                     ])
-                    await _send_msg(session, FEED_ROOM, relay)
+                    await _send_msg(client, FEED_ROOM, relay)
                 audit({"type": "promoted", "user": meta["mxid"],
                        "displayname": displayname, "room": room_id,
                        "haiku": text, "title": meta.get("title"),
@@ -291,22 +336,19 @@ async def process_vetting_room(session, room_id, meta, join_ev, msgs):
             return meta
         meta["tries_left"] -= 1
         if meta["tries_left"] <= 0:
-            await _send_msg(session, room_id,
+            await _send_msg(client, room_id,
                 "out of tries. closing this room — get a fresh code and try again.")
-            async with session.post(
-                f"{HS}/_matrix/client/v3/rooms/{room_id}/leave",
-                json={"reason": "vetting failed"}) as r:
-                pass
+            await _leave(client, room_id, reason="vetting failed")
             meta["closed"] = True
             meta["closed_reason"] = "tries_exhausted"
             audit({"type": "vetting_failed", "user": meta["mxid"], "room": room_id})
             return meta
-        await _send_msg(session, room_id,
+        await _send_msg(client, room_id,
             f"not yet — {why}. {meta['tries_left']} tries left.")
     return meta
 
 
-async def cleanup_stale_vetting(session, vetting_state):
+async def cleanup_stale_vetting(client, vetting_state):
     """Leave vetting rooms older than VETTING_TIMEOUT. Returns True if state changed."""
     now = time.time()
     dirty = False
@@ -314,10 +356,7 @@ async def cleanup_stale_vetting(session, vetting_state):
         if meta.get("promoted") or meta.get("closed"):
             continue
         if now - meta.get("created", 0) > VETTING_TIMEOUT:
-            async with session.post(
-                f"{HS}/_matrix/client/v3/rooms/{vroom}/leave",
-                json={"reason": "vetting timeout"}) as r:
-                pass
+            await _leave(client, vroom, reason="vetting timeout")
             meta["closed"] = True
             meta["closed_reason"] = "timeout"
             audit({"type": "vetting_timeout", "user": meta["mxid"], "room": vroom})
@@ -349,49 +388,34 @@ FEED_ROOM = os.environ.get("FEED_ROOM") or ADMIN_COMMAND_ROOM
 OUR_MXID = ""
 
 
-async def _whoami(session):
-    async with session.get(f"{HS}/_matrix/client/v3/account/whoami") as r:
-        if r.status != 200:
-            raise RuntimeError(f"whoami: {r.status} {(await r.text())[:200]}")
-        return (await r.json())["user_id"]
+async def _whoami(client):
+    resp = await client.api.request("GET", "/_matrix/client/v3/account/whoami")
+    return resp["user_id"], resp.get("device_id", "")
 
 
-async def _get_user_pl(session, room_id, mxid):
-    url = f"{HS}/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels"
-    async with session.get(url) as r:
-        if r.status != 200:
-            return 0
-        pl = await r.json()
+async def _get_user_pl(client, room_id, mxid):
+    try:
+        pl = await client.api.request("GET",
+            f"/_matrix/client/v3/rooms/{room_id}/state/m.room.power_levels")
+    except Exception:
+        return 0
     users = pl.get("users") or {}
     if mxid in users:
         return int(users[mxid])
     return int(pl.get("users_default", 0))
 
 
-async def _is_admin(session, room_id, sender):
+async def _is_admin(client, room_id, sender):
     if sender in ADMIN_ALLOWLIST:
         return True
-    return (await _get_user_pl(session, room_id, sender)) >= ADMIN_PL_THRESHOLD
-
-
-def iter_admin_commands(rooms_data, admin_room_id):
-    rd = rooms_data.get("join", {}).get(admin_room_id)
-    if not rd:
-        return
-    for ev in rd.get("timeline", {}).get("events", []):
-        if ev.get("type") != "m.room.message":
-            continue
-        body = ((ev.get("content") or {}).get("body", "") or "").strip()
-        if not body.startswith("!"):
-            continue
-        yield ev.get("event_id", ""), ev.get("sender", ""), body
+    return (await _get_user_pl(client, room_id, sender)) >= ADMIN_PL_THRESHOLD
 
 
 def _new_code():
     return secrets.token_urlsafe(6).rstrip("=").replace("_", "").replace("-", "")[:9] or secrets.token_hex(4)
 
 
-async def cmd_mint(session, room_id, sender, args):
+async def cmd_mint(client, room_id, sender, args):
     """!mint [knock|signup] [-n N] [--uses U] [label]  — generate codes.
 
     -n N        number of distinct codes (default 1)
@@ -466,7 +490,7 @@ async def cmd_mint(session, room_id, sender, args):
     return "\n".join(lines)
 
 
-async def cmd_codes(session, room_id, sender, args):
+async def cmd_codes(client, room_id, sender, args):
     """!codes — list current valid codes."""
     out = []
     for label_name, p in (("knock", CODES_PATH), ("signup", SIGNUP_PATH)):
@@ -480,7 +504,7 @@ async def cmd_codes(session, room_id, sender, args):
     return "\n".join(out) if out else "no live codes."
 
 
-async def cmd_revoke(session, room_id, sender, args):
+async def cmd_revoke(client, room_id, sender, args):
     """!revoke <code> — zero out a code's uses_remaining."""
     code = args.strip()
     if not code:
@@ -503,14 +527,14 @@ COMMANDS = {
     "!help": None,  # filled below
 }
 
-async def cmd_help(session, room_id, sender, args):
+async def cmd_help(client, room_id, sender, args):
     return ("commands: " +
             ", ".join(sorted(c for c in COMMANDS if c != "!help")) +
             ", !help")
 COMMANDS["!help"] = cmd_help
 
 
-async def process_admin_command(session, room_id, event_id, sender, body):
+async def process_admin_command(client, room_id, event_id, sender, body):
     if not OUR_MXID:
         # /whoami failed at startup; refuse to process anything to avoid
         # ever responding to our own replies (which would loop).
@@ -523,69 +547,171 @@ async def process_admin_command(session, room_id, event_id, sender, body):
     handler = COMMANDS.get(cmd)
     if not handler:
         return
-    if not await _is_admin(session, room_id, sender):
-        await _send_msg(session, room_id,
+    is_admin = await _is_admin(client, room_id, sender)
+    print(f"[admin] dispatch {cmd} from {sender} is_admin={is_admin}", flush=True)
+    if not is_admin:
+        await _send_msg(client, room_id,
             f"{sender}: refused — need PL >= {ADMIN_PL_THRESHOLD} or be on the allowlist")
         audit({"type": "admin_refused", "cmd": cmd, "sender": sender})
         return
     try:
-        result = await handler(session, room_id, sender, args)
+        result = await handler(client, room_id, sender, args)
     except Exception as e:
         result = f"!{cmd[1:]} failed: {type(e).__name__}: {e}"
         print(f"[admin] {cmd} crashed: {e}", flush=True)
-    await _send_msg(session, room_id, result)
+    print(f"[admin] sending reply: {result[:120]!r}", flush=True)
+    await _send_msg(client, room_id, result)
+
+
+# Helper for OlmMachine. Tracks which rooms we're joined to so the
+# crypto state store can answer find_shared_rooms.
+class _StateStore:
+    def __init__(self, inner):
+        self._inner, self._joined = inner, set()
+    async def is_encrypted(self, rid):
+        return (await self.get_encryption_info(rid)) is not None
+    async def get_encryption_info(self, rid):
+        if hasattr(self._inner, "get_encryption_info"):
+            return await self._inner.get_encryption_info(rid)
+        return None
+    async def find_shared_rooms(self, uid):
+        return list(self._joined)
 
 
 async def sync_loop():
+    """Mautrix-based sync loop with full E2EE support.
+
+    Replaces the previous raw-HTTP /sync. Mautrix decrypts incoming
+    encrypted events in place via OlmMachine, and our send_message_event
+    calls auto-encrypt outbound to any room with m.room.encryption set.
+
+    Cleartext flows (knock events on the space, vetting rooms) keep
+    working unchanged — iter_knock_events and iter_vetting_rooms read
+    raw event dicts which mautrix returns in the same shape.
+
+    Admin commands route through an event-handler so the bot processes
+    DECRYPTED versions even when ADMIN_COMMAND_ROOM is E2EE.
+    """
     global OUR_MXID
-    since = SYNC_STATE.read_text().strip() if SYNC_STATE.exists() else None
-    timeout = aiohttp.ClientTimeout(total=None, sock_read=45)
-    async with aiohttp.ClientSession(headers=AUTH, timeout=timeout) as s:
+
+    api = _MAU_HTTPAPI(base_url=HS, token=TOKEN)
+    state_store = _MAU_MemoryStateStore()
+    sync_store_obj = _MAU_MemorySyncStore()
+
+    # Resolve our identity via /whoami before the Client constructor
+    # (mautrix needs mxid + device_id baked in).
+    try:
+        whoami = await api.request("GET", "/_matrix/client/v3/account/whoami")
+        OUR_MXID = whoami["user_id"]
+        device_id = whoami.get("device_id", "approver")
+    except Exception as e:
+        print(f"[startup] whoami failed: {e}", flush=True)
+        # Fall through with empty mxid; admin commands will refuse.
+        OUR_MXID = ""
+        device_id = "approver-fallback"
+
+    client = _MAU_Client(mxid=_MAU_UserID(OUR_MXID or "@unknown:localhost"),
+                         device_id=device_id, api=api,
+                         state_store=state_store, sync_store=sync_store_obj)
+
+    CRYPTO_DB.parent.mkdir(parents=True, exist_ok=True)
+    db = _MAU_Database.create(f"sqlite:///{CRYPTO_DB}",
+                               upgrade_table=_MAU_PgCryptoStore.upgrade_table)
+    await db.start()
+    cs = _MAU_PgCryptoStore(account_id=OUR_MXID or "approver",
+                             pickle_key=f"{OUR_MXID}:{device_id}", db=db)
+    await cs.open()
+    ss = _StateStore(state_store)
+    olm = _MAU_OlmMachine(client, cs, ss)
+    olm.share_keys_min_trust = _MAU_TrustState.UNVERIFIED
+    olm.send_keys_min_trust = _MAU_TrustState.UNVERIFIED
+    await olm.load()
+    client.crypto = olm
+    client.crypto_store = cs
+
+    # Queue admin-command events as they arrive (mautrix decrypts before
+    # invoking handlers). Drained once per sync cycle below.
+    admin_queue = asyncio.Queue()
+
+    async def on_room_message(evt):
         try:
-            OUR_MXID = await _whoami(s)
-            print(f"[startup] running as {OUR_MXID}; admin room={ADMIN_COMMAND_ROOM}; "
-                  f"allowlist={sorted(ADMIN_ALLOWLIST) or '(empty)'}", flush=True)
+            ev_room = str(evt.room_id)
+            ev_sender = str(evt.sender)
+            if ev_room != ADMIN_COMMAND_ROOM:
+                return
+            if ev_sender == OUR_MXID:
+                return
+            body = (getattr(evt.content, "body", "") or "").strip()
+            if not body.startswith("!"):
+                return
+            await admin_queue.put((str(evt.event_id), ev_sender, body))
         except Exception as e:
-            print(f"[startup] whoami failed: {e}", flush=True)
-        while True:
-            params = {"timeout": "30000"}
-            if since:
-                params["since"] = since
-            try:
-                async with s.get(f"{HS}/_matrix/client/v3/sync", params=params) as r:
-                    if r.status != 200:
-                        print(f"[sync {r.status}] {(await r.text())[:300]}", flush=True)
-                        await asyncio.sleep(5)
-                        continue
-                    data = await r.json()
-            except asyncio.TimeoutError:
-                continue
-            except Exception as e:
-                print(f"[sync error] {type(e).__name__}: {e}", flush=True)
-                await asyncio.sleep(5)
-                continue
-            since = data["next_batch"]
+            print(f"[admin handler] {type(e).__name__}: {e}", flush=True)
+
+    client.add_event_handler(_MAU_EventType.ROOM_MESSAGE, on_room_message)
+
+    try:
+        await client.crypto.share_keys()
+    except Exception as e:
+        print(f"[startup] share_keys failed (continuing): {e}", flush=True)
+
+    print(f"[startup] running as {OUR_MXID}; device={device_id}; "
+          f"admin room={ADMIN_COMMAND_ROOM}; "
+          f"allowlist={sorted(ADMIN_ALLOWLIST) or '(empty)'}", flush=True)
+
+    since = SYNC_STATE.read_text().strip() if SYNC_STATE.exists() else None
+
+    while True:
+        try:
+            data = await client.sync(since=since, timeout=30000)
+        except Exception as e:
+            print(f"[sync error] {type(e).__name__}: {e}", flush=True)
+            await asyncio.sleep(5)
+            continue
+        if not isinstance(data, dict):
+            continue
+        next_batch = data.get("next_batch")
+        if next_batch:
+            since = next_batch
             SYNC_STATE.write_text(since)
 
-            for room_id, user_id, reason in iter_knock_events(data.get("rooms", {})):
-                await handle_knock(s, room_id, user_id, reason)
+        # Update joined-rooms tracking so OlmMachine can answer find_shared_rooms.
+        ss._joined.clear()
+        ss._joined.update(data.get("rooms", {}).get("join", {}).keys())
 
-            vetting_state = _load(VETTING_PATH)
-            v_dirty = False
-            for vroom, meta, join_ev, msgs in iter_vetting_rooms(
-                    data.get("rooms", {}), vetting_state):
-                updated = await process_vetting_room(s, vroom, meta, join_ev, msgs)
-                if updated is not None:
-                    vetting_state[vroom] = updated
-                    v_dirty = True
-            if await cleanup_stale_vetting(s, vetting_state):
+        # Decrypt + dispatch event handlers (this populates admin_queue).
+        try:
+            tasks = client.handle_sync(data)
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+        except Exception as e:
+            print(f"[handle_sync error] {type(e).__name__}: {e}", flush=True)
+
+        # Cleartext flows — knock events on the space + vetting rooms.
+        for room_id, user_id, reason in iter_knock_events(data.get("rooms", {})):
+            await handle_knock(client, room_id, user_id, reason)
+
+        vetting_state = _load(VETTING_PATH)
+        v_dirty = False
+        for vroom, meta, join_ev, msgs in iter_vetting_rooms(
+                data.get("rooms", {}), vetting_state):
+            updated = await process_vetting_room(client, vroom, meta, join_ev, msgs)
+            if updated is not None:
+                vetting_state[vroom] = updated
                 v_dirty = True
-            if v_dirty:
-                _save(VETTING_PATH, vetting_state)
+        if await cleanup_stale_vetting(client, vetting_state):
+            v_dirty = True
+        if v_dirty:
+            _save(VETTING_PATH, vetting_state)
 
-            for ev_id, sender, body in iter_admin_commands(
-                    data.get("rooms", {}), ADMIN_COMMAND_ROOM):
-                await process_admin_command(s, ADMIN_COMMAND_ROOM, ev_id, sender, body)
+        # Drain queued admin commands (event handler may have populated
+        # them with decrypted message events).
+        while not admin_queue.empty():
+            try:
+                ev_id, sender, body = admin_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            await process_admin_command(client, ADMIN_COMMAND_ROOM, ev_id, sender, body)
 
 
 # --- Signup auth proxy ---

--- a/tests/admin_e2ee.py
+++ b/tests/admin_e2ee.py
@@ -1,0 +1,176 @@
+"""End-to-end test of admin commands in an encrypted room.
+
+Covers the mautrix migration: the bot decrypts incoming `!mint` (and
+friends) sent in an E2EE room and replies with an encrypted message
+that the test client can decrypt back. If the migration regresses, this
+test fails — the haiku captcha isn't enough to cover this path.
+
+What it asserts:
+  1. A mautrix client signed in as the admin user (allowlisted) joins
+     the encrypted ADMIN_COMMAND_ROOM.
+  2. Sends `!mint --uses 3 admin-e2ee-test` via send_message_event
+     (auto-encrypted because the room has m.room.encryption).
+  3. Within ~30s, sees a reply event from @admin (the bot in this
+     test stack) whose decrypted body contains a `/join?code=…` URL.
+  4. The minted code shows up in `/data/codes.json` on the bot side
+     (validated indirectly via /signup-or-knock or /codes — for v1
+     we just trust the URL).
+
+Env (set by run_in_runner.sh):
+  DEV_HS, DEV_REG_TOKEN, ADMIN_COMMAND_ROOM, ADMIN_MXID
+"""
+import asyncio, json, os, secrets, sys, time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tests"))
+
+# Reuse the make_client + sync_once helpers from the existing E2EE test.
+from sas_e2e import make_client, sync_once, register
+
+from mautrix.types import (EventType, MessageType, TextMessageEventContent)
+
+HS = os.environ.get("DEV_HS", "http://landing:80").rstrip("/")
+REG_TOKEN = os.environ["DEV_REG_TOKEN"]
+ADMIN_ROOM = os.environ["ADMIN_COMMAND_ROOM"]
+
+# The bot's own mxid in the test stack — the bootstrap admin user is
+# the bot here (single-user test env). The PROD bot is @shape-rotator-2;
+# in prod tests we'd use that instead.
+BOT_MXID_HINT = os.environ.get("ADMIN_MXID", "")
+
+results = []
+def log(name, ok, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {name}" + (f"  ({detail})" if detail else ""), flush=True)
+    results.append((name, ok))
+
+
+async def main():
+    # The bootstrap admin is also our bot AND on the implicit allowlist
+    # (it has PL 100 in the space → passes the PL gate). For the test we
+    # need a SECOND user who is also on the allowlist OR has PL ≥ 50, and
+    # who has E2EE-capable client to send the !mint.
+    #
+    # Simpler shape for v1: register a fresh user, set ADMIN_ALLOWLIST
+    # via a !mint shouldn't actually need it — wait, the bot does need
+    # to see this user as admin. Easiest: bump PL of the new user in
+    # ADMIN_ROOM to 50 via an admin token call.
+    username = f"admin_e2ee_{int(time.time())}_{secrets.token_hex(2)}"
+    device   = f"E2EEADMIN{secrets.token_hex(2)}"
+    user_mxid, user_token = register(username, secrets.token_urlsafe(32), device)
+    print(f"[admin_e2ee] test user: {user_mxid} device={device}", flush=True)
+
+    # Bump PL of the test user in ADMIN_ROOM so they pass the bot's
+    # _is_admin gate. The bootstrap admin (= bot here) has PL 100 and
+    # can write power_levels.
+    import urllib.request, urllib.parse
+    admin_token = os.environ.get("ADMIN_TOKEN", "")
+    if not admin_token:
+        print("FAIL: no ADMIN_TOKEN env (needed to bump PL on test user)", file=sys.stderr)
+        sys.exit(2)
+
+    pl_url = f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(ADMIN_ROOM)}/state/m.room.power_levels"
+    # Read current
+    req = urllib.request.Request(pl_url, headers={"Authorization": f"Bearer {admin_token}"})
+    cur_pl = json.loads(urllib.request.urlopen(req).read())
+    cur_pl.setdefault("users", {})
+    cur_pl["users"][user_mxid] = 50
+    # Write back
+    body = json.dumps(cur_pl).encode()
+    req = urllib.request.Request(pl_url, data=body, method="PUT",
+                                  headers={"Authorization": f"Bearer {admin_token}",
+                                           "Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as r:
+        log("bumped test user PL to 50 in admin room", r.status == 200, f"status={r.status}")
+
+    # Invite + auto-accept invite to ADMIN_ROOM via raw HTTP (it's encrypted,
+    # but join is a state event, no encryption needed). Note: room is
+    # restricted-join via space membership, but we're not in the space
+    # yet — explicit invite is the simpler path here.
+    inv_url = f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(ADMIN_ROOM)}/invite"
+    req = urllib.request.Request(inv_url, method="POST",
+        data=json.dumps({"user_id": user_mxid}).encode(),
+        headers={"Authorization": f"Bearer {admin_token}",
+                 "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            log("invited test user to admin room", r.status == 200, f"status={r.status}")
+    except Exception as e:
+        log("invited test user to admin room", False, f"err={e}")
+
+    # Spin up mautrix client + accept invite + start syncing.
+    client, cs, ss, db = await make_client(
+        user_mxid, user_token, device,
+        db_path=f"/tmp/admin_e2ee_{secrets.token_hex(4)}.db")
+    await client.crypto.share_keys()
+
+    # Accept invite via raw join.
+    join_url = f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(ADMIN_ROOM)}/join"
+    req = urllib.request.Request(join_url, method="POST", data=b"{}",
+        headers={"Authorization": f"Bearer {user_token}",
+                 "Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as r:
+        log("test user joined admin room", r.status == 200, f"status={r.status}")
+
+    # Initial sync to learn room state + member device keys.
+    for _ in range(3):
+        await sync_once(client, ss, timeout=2000, first=True)
+
+    enc = await ss.is_encrypted(ADMIN_ROOM)
+    log("admin room reports encrypted", bool(enc))
+
+    # Send !mint via mautrix's send_message_event — auto-encrypts.
+    label = f"admin-e2ee-{secrets.token_hex(3)}"
+    cmd = f"!mint --uses 3 {label}"
+    sent_id = await client.send_message_event(
+        ADMIN_ROOM, EventType.ROOM_MESSAGE,
+        TextMessageEventContent(msgtype=MessageType.TEXT, body=cmd))
+    log("sent encrypted !mint command", bool(sent_id), f"event_id={sent_id}")
+
+    # Poll for the bot's reply: decrypted body should contain the label
+    # we passed AND a /join?code= URL.
+    deadline = time.time() + 45
+    seen_reply = None
+    received = asyncio.Event()
+
+    all_seen = []
+    async def on_msg(evt):
+        nonlocal seen_reply
+        body = (getattr(evt.content, "body", "") or "")
+        if str(evt.room_id) == ADMIN_ROOM and str(evt.sender) != user_mxid:
+            all_seen.append((str(evt.sender), body))
+            print(f"[admin_e2ee] received from {evt.sender}: {body[:100]!r}", flush=True)
+        if evt.room_id != ADMIN_ROOM:
+            return
+        if evt.sender == user_mxid:
+            return  # our own !mint command echoing back
+        if "/join?code=" in body and label in body:
+            seen_reply = body
+            received.set()
+
+    client.add_event_handler(EventType.ROOM_MESSAGE, on_msg)
+    while time.time() < deadline and not received.is_set():
+        await sync_once(client, ss, timeout=2000)
+    log("bot replied with encrypted !mint result",
+        seen_reply is not None,
+        f"body[:120]={(seen_reply or '')[:120]!r} ; all_seen={all_seen!r}")
+    if seen_reply:
+        # Pull the URL out and confirm shape
+        import re
+        m = re.search(r"https?://\S+/join\?code=(\S+)", seen_reply)
+        log("reply contains a /join URL with code",
+            bool(m),
+            f"code={m.group(1) if m else None!r}")
+
+    await db.stop()
+
+    failed = [name for name, ok in results if not ok]
+    print(f"\n=== {len(results) - len(failed)}/{len(results)} pass ===")
+    if failed:
+        print("FAILED: " + ", ".join(failed), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -58,7 +58,10 @@ services:
         grep -v '^#' /shared/test.env | sed 's/=.*/=<redacted>/'
 
   knock-approver:
-    image: python:3.11-slim
+    # Reuse the test-runner image — it has libolm + mautrix preinstalled, so
+    # the approver's mautrix-based sync loop starts up in seconds rather
+    # than waiting on apt-get + pip install.
+    build: .
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -83,7 +86,7 @@ services:
         # rather than 2 hours.
         export VETTING_TIMEOUT_SEC=300
         export HTTP_PORT=8001
-        pip install --quiet aiohttp cryptography
+        export CRYPTO_DB=/data/bot_crypto.db
         exec python -u /app.py
 
   landing:

--- a/tests/run_in_runner.sh
+++ b/tests/run_in_runner.sh
@@ -55,6 +55,17 @@ DEV_HS="$HS" \
   ADMIN_MXID="$ADMIN_MXID" \
   python3 tests/vetting_e2e.py
 
+# E2EE admin-command test — verifies bot decrypts !mint in an encrypted
+# room and replies encrypted. This is the regression gate for the
+# mautrix-bot migration.
+echo "[runner] === admin_e2ee.py ==="
+DEV_HS="$HS" \
+  DEV_REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+  ADMIN_COMMAND_ROOM="$ADMIN_COMMAND_ROOM" \
+  ADMIN_TOKEN="$ADMIN_TOKEN" \
+  ADMIN_MXID="$ADMIN_MXID" \
+  python3 tests/admin_e2ee.py
+
 # Paste A+B+C SAS verification end-to-end. **Informational**: the
 # upstream SAS dance is tracked-flaky against continuwuity (issue #1) so
 # we run the test for visibility but don't gate the PR on its outcome.


### PR DESCRIPTION
Closes the implementation half of #7. Bot now decrypts incoming admin commands and auto-encrypts replies, so `#matrix-devops` can be flipped to E2EE without `!mint` going dark.

## What changed

- **Sync loop migrated to mautrix** — `Client` + `OlmMachine` with persistent `PgCryptoStore` at `/data/bot_crypto.db`. `share_keys()` on startup uploads the bot's device keys; `handle_sync` decrypts incoming events + dispatches handlers. Old raw-HTTP `/sync` polling gone.
- **`_send_msg` uses `client.send_message_event`** — auto-encrypts based on room state. So vetting rooms (cleartext) get cleartext messages, the admin room (will be E2EE in prod) gets megolm.
- **All side-effect helpers moved** to `client.api.request` from aiohttp: `_create_vetting_room`, `_promote`, `_kick`, `_leave`, `_whoami`, `_get_user_pl`.
- **Admin commands via event handler** instead of `iter_admin_commands`. Mautrix decrypts `m.room.encrypted` → `m.room.message` and dispatches to our `on_room_message` handler, which queues commands for the dispatcher.
- **Module-level mautrix imports** so missing deps fail at process start with a clear traceback rather than silently mid-sync.

## Cleartext flows untouched

`iter_knock_events` and `iter_vetting_rooms` still read raw event dicts — knocks happen on the cleartext space, vetting rooms are cleartext by design (low-friction onboarding for users without E2EE clients). No regression on the existing flows.

## HTTP `/signup/api` + `/signup/api/crosssign` untouched

Those run in the aiohttp web server, are short-lived, and don't need decryption. They keep their own aiohttp sessions.

## Tests

- **`smoke.py`** — 18/18 ✓ (cleartext flows still healthy)
- **`vetting_e2e.py`** — 18/18 ✓ (megolm round-trip between two onboarded users)
- **`admin_e2ee.py`** *(new)* — 7/7 ✓
  - Registers a fresh user
  - Bumps their PL to 50 in the encrypted admin room
  - Joins the room, syncs, sends `!mint --uses 3 admin-e2ee-<n>` via `send_message_event` (auto-encrypted)
  - Asserts bot's reply (also encrypted) contains a `/join?code=…` URL with the requested label
- **`sas_e2e.py`** PASS

`tests/run_in_runner.sh` adds the new test as a third gating step.

`dev/bootstrap.py` now emits `ADMIN_COMMAND_ROOM` pointing at the (encrypted) `bot-noise` child so the bot in the test stack listens to a real E2EE room.

## Compose changes

- **Test stack** (`tests/docker-compose.test.yml`): `knock-approver` service now uses `build: .` (the test-runner Dockerfile, which already has libolm + mautrix). Approver starts in seconds, no install delay during the e2e harness.
- **Prod stack** (`docker-compose.yml`): inline `pip install` line on the `python:3.11-slim` image expanded to include `mautrix asyncpg aiosqlite python-olm unpaddedbase64 base58 pyaes` plus apt-get of `libolm3 libolm-dev gcc`. First boot is ~60s slower while the install happens; subsequent boots reuse the apt+pip layer caches. Custom image is a follow-up if startup time becomes an issue.

## Acceptance for #7

- [x] Bot decrypts incoming admin commands.
- [x] Bot encrypts outgoing replies.
- [x] Tests cover the E2EE round-trip.
- [ ] *Cross-signing-verified senders* (still in #20). This PR doesn't add the "refuse commands from un-cross-signed devices" check — that's the next layer of defense, separate work.
- [ ] *Move `#matrix-devops` to E2EE* — operator action after this lands. Single state PUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)