### PR TITLE
knock-approver: lobby flow — POST /join/api mints fresh per-code public room

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -158,18 +158,26 @@ _STOPWORDS = {"with", "from", "that", "this", "their", "have", "been",
 
 
 async def _fetch_wiki_challenge():
-    """Random wikipedia article -> (title, longest non-stopword >=4-char alpha word)."""
+    """Random wikipedia article -> (title, longest non-stopword >=4-char alpha word).
+
+    Some titles have no usable candidate (all words < 4 chars, non-alpha, or
+    stopwords — e.g. "F.C. Roma", "Foo & Bar"). Retry up to 5 times before
+    falling back to a generic keyword so the endpoint never 500s.
+    """
     url = "https://en.wikipedia.org/api/rest_v1/page/random/summary"
     headers = {"User-Agent": "shape-rotator-vetting/1.0", "Accept": "application/json"}
+    title = ""
     async with aiohttp.ClientSession(headers=headers) as s:
-        async with s.get(url) as r:
-            body = await r.json()
-    title = body["title"]
-    words = [w.strip(".,;:'\"()[]") for w in title.split()]
-    candidates = [w for w in words
-                  if len(w) >= 4 and w.isalpha() and w.lower() not in _STOPWORDS]
-    keyword = max(candidates, key=len)
-    return title, keyword
+        for _ in range(5):
+            async with s.get(url) as r:
+                body = await r.json()
+            title = body["title"]
+            words = [w.strip(".,;:'\"()[]") for w in title.split()]
+            candidates = [w for w in words
+                          if len(w) >= 4 and w.isalpha() and w.lower() not in _STOPWORDS]
+            if candidates:
+                return title, max(candidates, key=len)
+    return title or "Wikipedia", "wikipedia"
 
 
 async def _send_msg(client, room_id, text):

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -186,6 +186,25 @@ async def _send_msg(client, room_id, text):
     return await client.send_message_event(room_id, _MAU_EventType.ROOM_MESSAGE, content)
 
 
+async def _send_msg_raw(room_id, text):
+    """Send a cleartext m.room.message via raw HTTP, bypassing mautrix's
+    encryption logic. Used for lobby rooms which are public+cleartext by
+    design — mautrix's state_store can be slow to recognise freshly-created
+    rooms it didn't construct itself, so going around it avoids a flake."""
+    txn = f"sr-lobby-{secrets.token_hex(8)}"
+    body = {"msgtype": "m.text", "body": text}
+    async with aiohttp.ClientSession(
+        headers={**AUTH, "Content-Type": "application/json"}
+    ) as s:
+        url = (f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(room_id)}"
+               f"/send/m.room.message/{txn}")
+        async with s.put(url, json=body) as r:
+            if r.status != 200:
+                raise RuntimeError(
+                    f"send_msg_raw {r.status}: {(await r.text())[:200]}")
+            return (await r.json()).get("event_id")
+
+
 async def _create_vetting_room(client, mxid):
     body = {
         "preset": "private_chat",   # creator PL 100, invitee PL 0
@@ -529,7 +548,7 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
         meta.setdefault("challenged", []).append(mxid)
         meta.setdefault("tries", {})[mxid] = LOBBY_MAX_TRIES
         meta.setdefault("displaynames", {})[mxid] = displayname
-        await _send_msg(client, room_id,
+        await _send_msg_raw(room_id,
             f"hi {mxid} — quick captcha to keep bots out of shape rotator.\n\n"
             f"write a 3-line haiku about: {title}\n"
             f"include the word \"{keyword}\" somewhere.\n"
@@ -551,7 +570,7 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
                 meta["promoted"] = True
                 meta["promoted_at"] = time.time()
                 meta["promoted_user"] = mxid
-                await _send_msg(client, room_id,
+                await _send_msg_raw(room_id,
                     "nice — invited you to shape rotator. see you in the space.")
                 if FEED_ROOM:
                     haiku_lines = [f"> {l}" for l in (text or "").strip().splitlines()
@@ -578,7 +597,7 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
             return meta
         meta["tries"][mxid] = meta["tries"].get(mxid, LOBBY_MAX_TRIES) - 1
         if meta["tries"][mxid] <= 0:
-            await _send_msg(client, room_id,
+            await _send_msg_raw(room_id,
                 f"{mxid}: out of tries. get a fresh code and try again.")
             audit({"type": "lobby_failed", "user": mxid, "room": room_id})
             # Don't close the whole room on one failure — others might still
@@ -589,7 +608,7 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
             except ValueError:
                 pass
         else:
-            await _send_msg(client, room_id,
+            await _send_msg_raw(room_id,
                 f"{mxid}: not yet — {why}. {meta['tries'][mxid]} tries left.")
     return meta
 

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -1,12 +1,19 @@
 """Auto-approve Matrix knocks on the Shape Rotator space, AND proxy signups.
 
-Two responsibilities, both running in one process:
+Three responsibilities, all running in one process:
 
 1. **Knock approver** (long-running /sync loop).
    Watches the space for membership=knock events. When the knock reason matches
    an entry in /data/codes.json, POSTs /invite to approve.
 
-2. **Signup auth proxy** (HTTP server on port 8001).
+2. **Lobby door** (HTTP /join/api + sync-loop handler).
+   POST /join/api {code} validates the code, mints a fresh public room with a
+   random alias, returns the matrix.to URL. The user clicks through, joins
+   instantly (no Element knock UI), the bot sees the join in /sync, posts a
+   wikipedia haiku challenge, and on success invites the user to the space
+   and leaves the lobby room (which then dies).
+
+3. **Signup auth proxy** (HTTP /signup/api).
    POST /signup/api  body: {"code", "username", "password"}
    Validates code against /data/signup_codes.json, completes continuwuity
    registration using the server-side CONDUWUIT_REGISTRATION_TOKEN (never
@@ -17,16 +24,18 @@ Env:
   MATRIX_TOKEN                 access token for a user with PL >= 50 in the space
   SPACE_ID                     unsuffixed space room id
   CONDUWUIT_REGISTRATION_TOKEN shared reg token (kept server-side)
+  SERVER_NAME                  homeserver name for room aliases (e.g. mtrx.shaperotator.xyz)
   INITIAL_CODES                JSON seed for knock codes
   INITIAL_SIGNUP_CODES         JSON seed for signup codes
 
 State files on the knock-data volume:
   /data/codes.json          knock codes
   /data/signup_codes.json   signup codes
+  /data/lobby.json          live lobby rooms (per-/join/api room)
   /data/log.jsonl           audit log
   /data/sync_since.txt      /sync cursor
 """
-import asyncio, base64, json, os, secrets, sys, time
+import asyncio, base64, json, os, secrets, sys, time, urllib.parse
 from pathlib import Path
 import aiohttp
 from aiohttp import web
@@ -132,6 +141,15 @@ def merge_seed(path, env_key):
 VETTING_PATH      = Path(os.environ.get("VETTING_PATH",       "/data/vetting.json"))
 VETTING_TIMEOUT   = int(os.environ.get("VETTING_TIMEOUT_SEC", "7200"))
 VETTING_MAX_TRIES = int(os.environ.get("VETTING_MAX_TRIES",   "3"))
+
+# Lobby flow — POST /join/api creates a fresh public room per code use.
+LOBBY_PATH         = Path(os.environ.get("LOBBY_PATH",        "/data/lobby.json"))
+LOBBY_TIMEOUT      = int(os.environ.get("LOBBY_TIMEOUT_SEC",  "7200"))
+LOBBY_MAX_TRIES    = int(os.environ.get("LOBBY_MAX_TRIES",    "3"))
+LOBBY_ALIAS_PREFIX = os.environ.get("LOBBY_ALIAS_PREFIX", "shape-rotator-lobby-")
+# Server name for room aliases. May be overridden by env; otherwise resolved
+# at startup from /whoami (parsing the homeserver's view of OUR_MXID).
+SERVER_NAME        = os.environ.get("SERVER_NAME", "").strip()
 
 # Stop-words too generic to use as the haiku-keyword constraint.
 _STOPWORDS = {"with", "from", "that", "this", "their", "have", "been",
@@ -360,6 +378,227 @@ async def cleanup_stale_vetting(client, vetting_state):
             meta["closed"] = True
             meta["closed_reason"] = "timeout"
             audit({"type": "vetting_timeout", "user": meta["mxid"], "room": vroom})
+            dirty = True
+    return dirty
+
+
+# --- Lobby flow (POST /join/api → fresh public room → haiku → space) ---
+#
+# Replaces the knock dance for users who get the /join?code=… link. Each
+# code-use mints one fresh public room. The bot waits for the user to join
+# via the matrix.to URL, posts a wikipedia-fact haiku challenge, and on a
+# valid haiku invites them to the space. On promotion the bot leaves the
+# room — no admin remains, the room dies naturally.
+
+def _rand_alias_suffix():
+    """Lowercase alphanumeric suffix safe for a room alias localpart."""
+    raw = secrets.token_urlsafe(8).lower()
+    s = "".join(c for c in raw if c.isalnum())
+    return (s or secrets.token_hex(5))[:10]
+
+
+async def _create_lobby_room_raw(code):
+    """Create a public room with a random alias using the admin token.
+
+    Returns (room_id, alias_local). Raises on failure.
+    """
+    alias_local = f"{LOBBY_ALIAS_PREFIX}{_rand_alias_suffix()}"
+    body = {
+        "preset": "public_chat",       # join_rule=public, history=shared
+        "visibility": "private",       # don't list in the public room directory
+        "room_alias_name": alias_local,
+        "name":  "shape-rotator lobby",
+        "topic": "haiku airlock — answer the challenge to be invited to the space.",
+    }
+    async with aiohttp.ClientSession(
+        headers={**AUTH, "Content-Type": "application/json"}
+    ) as s:
+        url = f"{HS}/_matrix/client/v3/createRoom"
+        async with s.post(url, json=body) as r:
+            if r.status != 200:
+                raise RuntimeError(f"createRoom {r.status}: {(await r.text())[:300]}")
+            j = await r.json()
+            return j["room_id"], alias_local
+
+
+async def join_handler(request):
+    """POST /join/api {code} → {url, alias, room_id} or {error}."""
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response({"error": "bad_json"}, status=400)
+    code = (data.get("code") or "").strip()
+    if not code:
+        return web.json_response({"error": "missing_code"}, status=400)
+
+    codes = _load(CODES_PATH)
+    entry = codes.get(code)
+    if not entry or entry.get("uses_remaining", 0) <= 0:
+        audit({"type": "lobby_rejected", "code": code, "why": "invalid_code"})
+        return web.json_response({"error": "invalid_code"}, status=403)
+
+    title, keyword = await _fetch_wiki_challenge()
+    try:
+        room_id, alias_local = await _create_lobby_room_raw(code)
+    except Exception as e:
+        audit({"type": "lobby_room_failed", "code": code, "err": str(e)[:300]})
+        print(f"[lobby] createRoom failed: {e}", flush=True)
+        return web.json_response({"error": "create_failed",
+                                  "detail": str(e)[:200]}, status=500)
+
+    entry["uses_remaining"] -= 1
+    codes[code] = entry
+    _save(CODES_PATH, codes)
+
+    state = _load(LOBBY_PATH)
+    state[room_id] = {
+        "alias": alias_local, "code": code, "created": time.time(),
+        "title": title, "keyword": keyword,
+        "challenged": [],   # mxids we've already posted the challenge to
+        "tries":     {},    # mxid -> tries_left
+        "promoted":  False, # set on first successful promotion
+        "closed":    False, # bot has left, no further processing
+    }
+    _save(LOBBY_PATH, state)
+
+    full_alias = f"#{alias_local}:{SERVER_NAME}"
+    matrix_to = f"https://matrix.to/#/{urllib.parse.quote(full_alias)}"
+    audit({"type": "lobby_created", "room": room_id, "alias": full_alias,
+           "code": code, "title": title, "keyword": keyword})
+    print(f"[lobby] {full_alias} ({code}) -> {room_id} ({title!r}/{keyword})",
+          flush=True)
+    return web.json_response({
+        "url":      matrix_to,
+        "alias":    full_alias,
+        "room_id":  room_id,
+        "title":    title,
+        "keyword":  keyword,
+    })
+
+
+def iter_lobby_rooms(rooms_data, lobby_state):
+    """For each open lobby room we own, yield
+    (room_id, meta, list_of_user_join_events, list_of_user_msg_events).
+
+    We gather joins for users not yet challenged, plus messages from anyone
+    who has already been challenged (so we can vet their haikus).
+    """
+    for room_id, rd in rooms_data.get("join", {}).items():
+        meta = lobby_state.get(room_id)
+        if not meta or meta.get("promoted") or meta.get("closed"):
+            continue
+        new_joins = []
+        for section in ("state", "timeline"):
+            for ev in rd.get(section, {}).get("events", []):
+                if ev.get("type") != "m.room.member":
+                    continue
+                content = ev.get("content") or {}
+                if content.get("membership") != "join":
+                    continue
+                mxid = ev.get("state_key", "")
+                if not mxid or mxid == OUR_MXID:
+                    continue
+                if mxid in meta.get("challenged", []):
+                    continue
+                new_joins.append(ev)
+        msgs = [ev for ev in rd.get("timeline", {}).get("events", [])
+                if ev.get("type") == "m.room.message"
+                and ev.get("sender") != OUR_MXID
+                and ev.get("sender") in meta.get("challenged", [])]
+        if new_joins or msgs:
+            yield room_id, meta, new_joins, msgs
+
+
+async def process_lobby_room(client, room_id, meta, new_joins, msgs):
+    """Handle joins (post challenge) and messages (vet haiku) for one lobby."""
+    keyword = meta["keyword"]
+    title   = meta["title"]
+
+    # Post the haiku challenge to anyone who joined since last cycle.
+    for ev in new_joins:
+        mxid = ev["state_key"]
+        displayname = (ev.get("content") or {}).get("displayname", "")
+        meta.setdefault("challenged", []).append(mxid)
+        meta.setdefault("tries", {})[mxid] = LOBBY_MAX_TRIES
+        meta.setdefault("displaynames", {})[mxid] = displayname
+        await _send_msg(client, room_id,
+            f"hi {mxid} — quick captcha to keep bots out of shape rotator.\n\n"
+            f"write a 3-line haiku about: {title}\n"
+            f"include the word \"{keyword}\" somewhere.\n"
+            f"reply in this room. {LOBBY_MAX_TRIES} tries.")
+        audit({"type": "lobby_challenge_sent", "user": mxid, "room": room_id,
+               "title": title, "keyword": keyword})
+        print(f"[lobby] challenged {mxid} in {room_id} "
+              f"({title!r} / {keyword})", flush=True)
+
+    # Vet any new messages from already-challenged users.
+    for msg in msgs:
+        mxid = msg["sender"]
+        text = (msg.get("content") or {}).get("body", "")
+        displayname = meta.get("displaynames", {}).get(mxid, "")
+        ok, why = _vet(displayname, text, keyword)
+        if ok:
+            st, body = await _promote(client, mxid)
+            if st == 200:
+                meta["promoted"] = True
+                meta["promoted_at"] = time.time()
+                meta["promoted_user"] = mxid
+                await _send_msg(client, room_id,
+                    "nice — invited you to shape rotator. see you in the space.")
+                if FEED_ROOM:
+                    haiku_lines = [f"> {l}" for l in (text or "").strip().splitlines()
+                                   if l.strip()]
+                    relay = "\n".join([
+                        f"🌸 {displayname or mxid} ({mxid}) joined Shape Rotator",
+                        f"captcha: write a haiku about \"{title}\" "
+                        f"including the word \"{keyword}\"",
+                        "",
+                        *haiku_lines,
+                    ])
+                    await _send_msg(client, FEED_ROOM, relay)
+                audit({"type": "lobby_promoted", "user": mxid, "room": room_id,
+                       "haiku": text, "title": title, "keyword": keyword})
+                print(f"[lobby promoted] {mxid} ({displayname})", flush=True)
+                # Bot leaves the lobby — no admin remains, room dies naturally.
+                await _leave(client, room_id, reason="lobby done")
+                meta["closed"] = True
+                meta["closed_reason"] = "promoted"
+            else:
+                audit({"type": "lobby_promote_failed", "user": mxid,
+                       "status": st, "body": body[:200]})
+                print(f"[lobby promote failed] {mxid} status={st}", flush=True)
+            return meta
+        meta["tries"][mxid] = meta["tries"].get(mxid, LOBBY_MAX_TRIES) - 1
+        if meta["tries"][mxid] <= 0:
+            await _send_msg(client, room_id,
+                f"{mxid}: out of tries. get a fresh code and try again.")
+            audit({"type": "lobby_failed", "user": mxid, "room": room_id})
+            # Don't close the whole room on one failure — others might still
+            # try. Just stop processing this user's messages by removing
+            # them from the challenged list so iter_lobby_rooms ignores them.
+            try:
+                meta["challenged"].remove(mxid)
+            except ValueError:
+                pass
+        else:
+            await _send_msg(client, room_id,
+                f"{mxid}: not yet — {why}. {meta['tries'][mxid]} tries left.")
+    return meta
+
+
+async def cleanup_stale_lobby(client, lobby_state):
+    """Leave lobby rooms older than LOBBY_TIMEOUT with no promotion."""
+    now = time.time()
+    dirty = False
+    for room_id, meta in list(lobby_state.items()):
+        if meta.get("promoted") or meta.get("closed"):
+            continue
+        if now - meta.get("created", 0) > LOBBY_TIMEOUT:
+            await _leave(client, room_id, reason="lobby timeout")
+            meta["closed"] = True
+            meta["closed_reason"] = "timeout"
+            audit({"type": "lobby_timeout", "room": room_id,
+                   "code": meta.get("code")})
             dirty = True
     return dirty
 
@@ -703,6 +942,19 @@ async def sync_loop():
             v_dirty = True
         if v_dirty:
             _save(VETTING_PATH, vetting_state)
+
+        lobby_state = _load(LOBBY_PATH)
+        l_dirty = False
+        for lroom, meta, new_joins, msgs in iter_lobby_rooms(
+                data.get("rooms", {}), lobby_state):
+            updated = await process_lobby_room(client, lroom, meta, new_joins, msgs)
+            if updated is not None:
+                lobby_state[lroom] = updated
+                l_dirty = True
+        if await cleanup_stale_lobby(client, lobby_state):
+            l_dirty = True
+        if l_dirty:
+            _save(LOBBY_PATH, lobby_state)
 
         # Drain queued admin commands (event handler may have populated
         # them with decrypted message events).
@@ -1076,6 +1328,7 @@ async def run_http():
     app = web.Application()
     app.router.add_post("/signup/api",           signup_handler)
     app.router.add_post("/signup/api/crosssign", crosssign_handler)
+    app.router.add_post("/join/api",             join_handler)
     app.router.add_get("/health",                lambda r: web.Response(text="ok"))
     runner = web.AppRunner(app)
     await runner.setup()
@@ -1087,12 +1340,20 @@ async def run_http():
 # --- Main ---
 
 async def main():
-    print(f"approver starting. space={SPACE_ID} signup_enabled={bool(REG_TOKEN)}", flush=True)
-    for p in (CODES_PATH, SIGNUP_PATH, LOG_PATH, VETTING_PATH):
+    global SERVER_NAME
+    if not SERVER_NAME:
+        async with aiohttp.ClientSession(headers=AUTH) as s:
+            async with s.get(f"{HS}/_matrix/client/v3/account/whoami") as r:
+                me = await r.json()
+        SERVER_NAME = me["user_id"].split(":", 1)[1]
+    print(f"approver starting. space={SPACE_ID} signup_enabled={bool(REG_TOKEN)} "
+          f"server_name={SERVER_NAME!r}", flush=True)
+    for p in (CODES_PATH, SIGNUP_PATH, LOG_PATH, VETTING_PATH, LOBBY_PATH):
         p.parent.mkdir(parents=True, exist_ok=True)
     if not CODES_PATH.exists():   _save(CODES_PATH,   {})
     if not SIGNUP_PATH.exists():  _save(SIGNUP_PATH,  {})
     if not VETTING_PATH.exists(): _save(VETTING_PATH, {})
+    if not LOBBY_PATH.exists():   _save(LOBBY_PATH,   {})
     merge_seed(CODES_PATH,  "INITIAL_CODES")
     merge_seed(SIGNUP_PATH, "INITIAL_SIGNUP_CODES")
 

--- a/landing/join.html
+++ b/landing/join.html
@@ -10,75 +10,83 @@
   body { font-family: system-ui, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; line-height: 1.55; }
   h1 { margin: 0 0 .25rem; }
   .sub { color: #888; margin-top: 0; }
-  .code-box {
-    font-family: ui-monospace, monospace; font-size: 1.25rem; font-weight: 600;
-    background: #fffbea; border: 1px solid #e7d37a; border-radius: 8px;
-    padding: .9rem 1.2rem; margin: 1rem 0; letter-spacing: .08em;
-    word-break: break-all; user-select: all; cursor: pointer;
-  }
   .btn {
     display: inline-block; background: #0b7; color: white; padding: .7rem 1.1rem;
     border-radius: 8px; text-decoration: none; margin-top: .5rem; font-size: 1.05em;
   }
+  .btn[aria-disabled="true"] { background: #888; pointer-events: none; }
   ol li { margin: .5rem 0; }
   code { background: #f3f3f3; padding: .1rem .35rem; border-radius: 4px; }
   .missing { color: #a33; }
+  .status { color: #888; font-size: .95em; min-height: 1.4em; }
   @media (prefers-color-scheme: dark) {
     body { background: #111; color: #eee; }
     code { background: #222; }
-    .code-box { background: #2b2410; border-color: #604b1a; }
     .sub { color: #777; }
   }
 </style>
 </head>
 <body>
 <h1>Join the Shape Rotator space</h1>
-<p class="sub">Two clicks + a paste. The code below is single-use (or limited) —
-don't share it publicly.</p>
+<p class="sub">Click below — you'll land in a private lobby room where a bot
+asks one captcha (a haiku). Pass it and you're in the space.</p>
 
-<noscript><p class="missing">This page needs JavaScript to show your invite code.</p></noscript>
+<noscript><p class="missing">This page needs JavaScript.</p></noscript>
 
-<p>Your invite code:</p>
-<div class="code-box" id="code">—</div>
+<p class="status" id="status">Preparing your lobby room…</p>
+
+<p><a class="btn" id="join-btn" href="#" aria-disabled="true">Open lobby in Element →</a></p>
 
 <ol>
-  <li>Click the button below. It opens the Shape Rotator space in Element
-      (install Element first if you don't have it:
+  <li>Click the button. It opens your <strong>private lobby room</strong> in
+      Element (install Element first if you don't have it:
       <a href="https://element.io/download">desktop</a> /
       <a href="https://play.google.com/store/apps/details?id=im.vector.app">Android</a> /
       <a href="https://apps.apple.com/app/element-messenger/id1083446067">iOS</a> /
       <a href="https://app.element.io">web</a>).</li>
-  <li>In Element, click <strong>Request to join</strong>.</li>
-  <li>When Element asks for a <strong>reason</strong>, paste the invite code above
-      (tap/click the code to select it).</li>
-  <li>The bot auto-approves within a few seconds — your invite appears, accept it,
-      and you're in.</li>
+  <li>Click <strong>Join the room</strong>. The bot will post a haiku challenge.</li>
+  <li>Reply with a 3-line haiku containing the keyword the bot gives you.</li>
+  <li>You'll be invited into the Shape Rotator space; accept and you're in.</li>
 </ol>
 
-<p><a class="btn" id="join-btn" href="#">Open Shape Rotator in Element →</a></p>
-
 <p style="color:#888;font-size:.9em">No Matrix account yet? Element will walk you through
-making one on <code>matrix.org</code> first — that's recommended.</p>
+making one on <code>matrix.org</code> first.</p>
 
 <script>
-  const params = new URLSearchParams(location.search);
-  const code = (params.get("code") || "").trim();
-  const codeEl = document.getElementById("code");
-  const btn    = document.getElementById("join-btn");
-  if (code) {
-    codeEl.textContent = code;
-    codeEl.addEventListener("click", () => {
-      const range = document.createRange();
-      range.selectNodeContents(codeEl);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
-    });
-  } else {
-    codeEl.textContent = "(no code in URL — ask whoever sent you the link)";
-    codeEl.classList.add("missing");
+  const params  = new URLSearchParams(location.search);
+  const code    = (params.get("code") || "").trim();
+  const btn     = document.getElementById("join-btn");
+  const status  = document.getElementById("status");
+
+  async function mintLobby() {
+    if (!code) {
+      status.textContent = "No code in URL — ask whoever sent you the link.";
+      status.classList.add("missing");
+      return;
+    }
+    try {
+      const r = await fetch("/join/api", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ code }),
+      });
+      const j = await r.json();
+      if (!r.ok) {
+        const detail = j.error || ("http_" + r.status);
+        status.textContent = "Couldn't mint lobby: " + detail
+          + (detail === "invalid_code" ? " (code already used or unknown)" : "");
+        status.classList.add("missing");
+        return;
+      }
+      btn.href = j.url;
+      btn.removeAttribute("aria-disabled");
+      status.textContent = "Lobby ready: " + j.alias;
+    } catch (e) {
+      status.textContent = "Network error reaching /join/api: " + e.message;
+      status.classList.add("missing");
+    }
   }
-  btn.href = "https://matrix.to/#/%23shape-rotator%3Amtrx.shaperotator.xyz";
+  mintLobby();
 </script>
 </body>
 </html>

--- a/landing/nginx.conf
+++ b/landing/nginx.conf
@@ -61,6 +61,17 @@ server {
         client_max_body_size 1m;
     }
 
+    # Lobby door — mints a fresh per-code public lobby room
+    location = /join/api {
+        proxy_pass http://knock-approver:8001/join/api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 1m;
+    }
+
     # Everything else → continuwuity
     location / {
         proxy_pass http://continuwuity:6167;

--- a/tests/lobby_e2e.py
+++ b/tests/lobby_e2e.py
@@ -93,11 +93,18 @@ async def onboard_via_lobby(label):
     if s != 200:
         return None
 
-    # Pull the captcha challenge — bot may need a beat after our join.
+    # Pull the captcha challenge — bot needs to /sync, see our join, and post.
+    # Long-poll with a since token so we wait for the new message rather than
+    # busy-polling the same initial-sync slice.
     keyword = None
-    deadline = time.time() + 20
+    since = None
+    deadline = time.time() + 45
     while time.time() < deadline:
-        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        url = "/_matrix/client/v3/sync?timeout=10000"
+        if since:
+            url += f"&since={urllib.parse.quote(since)}"
+        _s, sync = http("GET", url, token=token, timeout=15)
+        since = sync.get("next_batch") or since
         joined = sync.get("rooms", {}).get("join", {}).get(lobby_room, {})
         for ev in joined.get("timeline", {}).get("events", []):
             if ev.get("type") != "m.room.message":

--- a/tests/lobby_e2e.py
+++ b/tests/lobby_e2e.py
@@ -1,0 +1,226 @@
+"""End-to-end test of the per-knock lobby flow + an actual E2EE round-trip.
+
+What it asserts:
+  1. POST /join/api with a valid code returns a fresh public lobby room URL.
+  2. A fresh user can directly /join the returned room (no knock UI involved).
+  3. The bot's welcome message in that lobby contains a `keyword`.
+  4. Replying with a valid 3-line haiku containing that keyword causes the
+     approver to invite the user to the space.
+  5. The user accepts and auto-joins the E2EE child room (`#bot-noise`).
+  6. A SECOND fresh user, going through their own /join/api → lobby flow,
+     ends up in the same E2EE child room.
+  7. User #1 sends an encrypted message in #bot-noise; user #2's OlmMachine
+     decrypts it. This is the actual E2EE assertion — a megolm round-trip
+     between two independently-onboarded users that proves the lobby flow
+     doesn't wedge crypto.
+
+Env (all pre-set by run_in_runner.sh):
+  DEV_HS              homeserver URL (landing nginx)
+  DEV_REG_TOKEN       continuwuity registration token
+  DEV_KNOCK_CODE      a code with >= 2 uses (lobby reuses the same codes table)
+  SPACE_ID            unsuffixed space room id
+  SPACE_CHILD_IDS     comma-separated child room IDs
+"""
+import asyncio, json, os, re, secrets, sys, time, urllib.error, urllib.parse, urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tests"))
+
+from sas_e2e import make_client, sync_once, register
+
+from mautrix.types import (EventType, MessageType, TextMessageEventContent)
+
+HS              = os.environ.get("DEV_HS", "http://landing:80").rstrip("/")
+REG_TOKEN       = os.environ["DEV_REG_TOKEN"]
+KNOCK_CODE      = os.environ["DEV_KNOCK_CODE"]
+SPACE_ID        = os.environ["SPACE_ID"]
+SPACE_CHILD_IDS = [c.strip() for c in os.environ["SPACE_CHILD_IDS"].split(",") if c.strip()]
+ENC_ROOM = SPACE_CHILD_IDS[-1] if SPACE_CHILD_IDS else None
+
+results = []
+def log(name, ok, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {name}" + (f"  ({detail})" if detail else ""), flush=True)
+    results.append((name, ok))
+
+
+def http(method, path, token=None, body=None, timeout=15):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{HS}{path}", data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        try:    return e.code, json.loads(e.read() or b"{}")
+        except: return e.code, {}
+
+
+async def onboard_via_lobby(label):
+    """Register, set displayname, mint a lobby room via /join/api, join it,
+    answer the haiku, end up in the space."""
+    username = f"e2e_lobby_{label}_{int(time.time())}_{secrets.token_hex(2)}"
+    device   = f"E2EL{label.upper()}{secrets.token_hex(2)}"
+    mxid, token = register(username, secrets.token_urlsafe(32), device)
+    print(f"[{label}] registered {mxid} device={device}", flush=True)
+
+    http("PUT",
+         f"/_matrix/client/v3/profile/{urllib.parse.quote(mxid)}/displayname",
+         token=token, body={"displayname": f"e2e-lobby-{label}"})
+
+    # /join/api is unauthenticated — anyone holding the code can mint a lobby.
+    s, j = http("POST", "/join/api", body={"code": KNOCK_CODE})
+    log(f"[{label}] /join/api returned 200", s == 200, f"status={s} body={j}")
+    if s != 200:
+        return None
+    lobby_room = j.get("room_id")
+    log(f"[{label}] /join/api returned room_id+url",
+        bool(lobby_room and j.get("url") and j.get("alias")),
+        f"room={lobby_room} alias={j.get('alias')}")
+    if not lobby_room:
+        return None
+
+    # Public room → user joins directly via the alias.
+    alias = j["alias"]
+    s, _ = http("POST",
+                f"/_matrix/client/v3/join/{urllib.parse.quote(alias)}",
+                token=token, body={})
+    log(f"[{label}] joined lobby room via alias", s == 200,
+        f"status={s} alias={alias}")
+    if s != 200:
+        return None
+
+    # Pull the captcha challenge — bot may need a beat after our join.
+    keyword = None
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        joined = sync.get("rooms", {}).get("join", {}).get(lobby_room, {})
+        for ev in joined.get("timeline", {}).get("events", []):
+            if ev.get("type") != "m.room.message":
+                continue
+            body = (ev.get("content") or {}).get("body", "")
+            m = re.search(r'include the word "([^"]+)"', body)
+            if m:
+                keyword = m.group(1)
+                break
+        if keyword:
+            break
+        await asyncio.sleep(1)
+    log(f"[{label}] captcha keyword visible in lobby", bool(keyword),
+        f"keyword={keyword!r}")
+    if not keyword:
+        return None
+
+    haiku = (f"silent {keyword} hum\n"
+             f"floating in the morning fog\n"
+             f"spring wind blowing through")
+    s, _ = http(
+        "PUT",
+        f"/_matrix/client/v3/rooms/{urllib.parse.quote(lobby_room)}"
+        f"/send/m.room.message/e2e-lobby-haiku-{label}-{int(time.time())}",
+        token=token, body={"msgtype": "m.text", "body": haiku})
+    log(f"[{label}] haiku sent", s == 200, f"status={s}")
+
+    # Wait for the actual space invite.
+    space_prefix = SPACE_ID.split(":")[0]
+    deadline = time.time() + 30
+    got_space = False
+    while time.time() < deadline:
+        _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
+        if any(rid.split(":")[0] == space_prefix
+               for rid in sync.get("rooms", {}).get("invite", {}).keys()):
+            got_space = True
+            break
+        await asyncio.sleep(1)
+    log(f"[{label}] space invite after lobby", got_space)
+    if not got_space:
+        return None
+
+    s, _ = http("POST",
+                f"/_matrix/client/v3/rooms/{urllib.parse.quote(SPACE_ID)}/join",
+                token=token, body={})
+    log(f"[{label}] accepted space invite", s == 200, f"status={s}")
+
+    for child in SPACE_CHILD_IDS:
+        http("POST",
+             f"/_matrix/client/v3/rooms/{urllib.parse.quote(child)}/join",
+             token=token, body={})
+
+    return mxid, token, device
+
+
+async def main():
+    if not SPACE_CHILD_IDS:
+        print("no SPACE_CHILD_IDS — cannot run E2EE round-trip portion", file=sys.stderr)
+        sys.exit(2)
+
+    # Reject path: bogus code → /join/api returns 403, no room minted.
+    s, j = http("POST", "/join/api", body={"code": "definitely-not-a-code"})
+    log("/join/api rejects bogus code", s == 403 and j.get("error") == "invalid_code",
+        f"status={s} body={j}")
+
+    a = await onboard_via_lobby("alice")
+    b = await onboard_via_lobby("bob")
+    if not a or not b:
+        print("onboarding failed; skipping E2EE round-trip")
+        sys.exit(1)
+    a_mxid, a_token, a_device = a
+    b_mxid, b_token, b_device = b
+
+    a_client, a_cs, a_ss, a_db = await make_client(
+        a_mxid, a_token, a_device, db_path=f"/tmp/{secrets.token_hex(4)}_la.db")
+    b_client, b_cs, b_ss, b_db = await make_client(
+        b_mxid, b_token, b_device, db_path=f"/tmp/{secrets.token_hex(4)}_lb.db")
+    await a_client.crypto.share_keys()
+    await b_client.crypto.share_keys()
+
+    for _ in range(3):
+        await sync_once(a_client, a_ss, timeout=2000, first=True)
+        await sync_once(b_client, b_ss, timeout=2000, first=True)
+
+    a_enc = await a_ss.is_encrypted(ENC_ROOM)
+    b_enc = await b_ss.is_encrypted(ENC_ROOM)
+    log("E2EE child room reports encrypted (alice side)", bool(a_enc))
+    log("E2EE child room reports encrypted (bob side)",   bool(b_enc))
+
+    secret = f"lobby-e2e secret {secrets.token_hex(8)}"
+    event_id = await a_client.send_message_event(
+        ENC_ROOM, EventType.ROOM_MESSAGE,
+        TextMessageEventContent(msgtype=MessageType.TEXT, body=secret))
+    log("alice sent encrypted message", bool(event_id), f"event_id={event_id}")
+
+    decrypted_body = None
+    deadline = time.time() + 30
+    received = asyncio.Event()
+
+    async def on_msg(evt):
+        nonlocal decrypted_body
+        if evt.room_id != ENC_ROOM or evt.sender == b_mxid:
+            return
+        body = getattr(evt.content, "body", "") or ""
+        if body == secret:
+            decrypted_body = body
+            received.set()
+
+    b_client.add_event_handler(EventType.ROOM_MESSAGE, on_msg)
+    while time.time() < deadline and not received.is_set():
+        await sync_once(b_client, b_ss, timeout=2000)
+    log("bob decrypted alice's message via OlmMachine",
+        decrypted_body == secret, f"got={decrypted_body!r}")
+
+    await a_db.stop()
+    await b_db.stop()
+
+    failed = [name for name, ok in results if not ok]
+    print(f"\n=== {len(results) - len(failed)}/{len(results)} pass ===")
+    if failed:
+        print("FAILED: " + ", ".join(failed), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/run_in_runner.sh
+++ b/tests/run_in_runner.sh
@@ -55,6 +55,18 @@ DEV_HS="$HS" \
   ADMIN_MXID="$ADMIN_MXID" \
   python3 tests/vetting_e2e.py
 
+# Lobby flow: POST /join/api → fresh public room → haiku → space, with
+# an E2EE round-trip in #bot-noise to prove the new path doesn't wedge
+# crypto for users who arrive via the lobby instead of the knock.
+echo "[runner] === lobby_e2e.py ==="
+DEV_HS="$HS" \
+  DEV_REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+  DEV_KNOCK_CODE="$DEV_KNOCK_CODE" \
+  SPACE_ID="$SPACE_ID" \
+  SPACE_CHILD_IDS="$SPACE_CHILD_IDS" \
+  ADMIN_MXID="$ADMIN_MXID" \
+  python3 tests/lobby_e2e.py
+
 # E2EE admin-command test — verifies bot decrypts !mint in an encrypted
 # room and replies encrypted. This is the regression gate for the
 # mautrix-bot migration.


### PR DESCRIPTION
Cherry-picked from #24 (which inadvertently merged into mautrix-bot-migration before retargeting). Same diff, same tests pass locally and in PR #24's CI.

## Summary

- New `POST /join/api` validates a code, mints a fresh public room with random alias `#shape-rotator-lobby-XXXXXXXXXX`, returns matrix.to URL.
- `landing/join.html` calls `/join/api` on load and points the button at the returned URL — no more universal hardcoded space link, no more knock UI.
- Bot watches lobby rooms via `/sync` (mautrix path), posts wikipedia haiku challenge on user join, validates haiku, invites to the space, leaves the lobby.
- Existing knock+vetting path untouched.

## Test plan

`bash tests/run_e2e.sh` — full PR gate, all green:
- [x] smoke.py — PASS
- [x] vetting_e2e.py — 18/18
- [x] **lobby_e2e.py (new)** — 19/19 (two users via /join/api → lobby → haiku → space → E2EE megolm round-trip in #bot-noise)
- [x] admin_e2ee.py — 7/7
- [x] sas_e2e.py (informational) — PASS