### PR TITLE
approver: treat 403-on-promote as already-member success

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -566,13 +566,24 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
         ok, why = _vet(displayname, text, keyword)
         if ok:
             st, body = await _promote(client, mxid)
-            if st == 200:
+            # /invite returning 403 means either "already in the room" or
+            # the bot lacks PL. The bot has PL by construction (alice/bob's
+            # first promote works); the only realistic 403 in this flow is
+            # "already member." Treat it as success so re-running the lobby
+            # works cleanly as a debug self-test.
+            already_member = (st == 403)
+            if already_member:
+                print(f"[lobby] promote 403 — assuming already-member. "
+                      f"body={body[:200]}", flush=True)
+            if st == 200 or already_member:
                 meta["promoted"] = True
                 meta["promoted_at"] = time.time()
                 meta["promoted_user"] = mxid
-                await _send_msg_raw(room_id,
-                    "nice — invited you to shape rotator. see you in the space.")
-                if FEED_ROOM:
+                ack = ("you're already in shape rotator — see you in the space."
+                       if already_member else
+                       "nice — invited you to shape rotator. see you in the space.")
+                await _send_msg_raw(room_id, ack)
+                if FEED_ROOM and not already_member:
                     haiku_lines = [f"> {l}" for l in (text or "").strip().splitlines()
                                    if l.strip()]
                     relay = "\n".join([
@@ -584,12 +595,15 @@ async def process_lobby_room(client, room_id, meta, new_joins, msgs):
                     ])
                     await _send_msg(client, FEED_ROOM, relay)
                 audit({"type": "lobby_promoted", "user": mxid, "room": room_id,
-                       "haiku": text, "title": title, "keyword": keyword})
-                print(f"[lobby promoted] {mxid} ({displayname})", flush=True)
-                # Bot leaves the lobby — no admin remains, room dies naturally.
+                       "haiku": text, "title": title, "keyword": keyword,
+                       "already_member": already_member})
+                print(f"[lobby promoted] {mxid} ({displayname})"
+                      f"{' (already in space)' if already_member else ''}",
+                      flush=True)
                 await _leave(client, room_id, reason="lobby done")
                 meta["closed"] = True
-                meta["closed_reason"] = "promoted"
+                meta["closed_reason"] = ("already_member" if already_member
+                                         else "promoted")
             else:
                 audit({"type": "lobby_promote_failed", "user": mxid,
                        "status": st, "body": body[:200]})

--- a/tests/lobby_e2e.py
+++ b/tests/lobby_e2e.py
@@ -222,6 +222,77 @@ async def main():
     await a_db.stop()
     await b_db.stop()
 
+    # Second-pass debug case: alice (now an existing space member) re-runs
+    # the lobby flow. The bot should still post the haiku, accept the answer,
+    # and acknowledge with the "already in space" success ack — proving the
+    # invite-403-because-already-member path is treated as success so an
+    # operator can self-test the whole flow without spinning up new accounts.
+    s, j = http("POST", "/join/api", body={"code": KNOCK_CODE})
+    log("[alice-redo] /join/api returned 200 for existing member",
+        s == 200, f"status={s}")
+    if s == 200:
+        redo_room = j["room_id"]
+        s2, _ = http("POST",
+                     f"/_matrix/client/v3/join/{urllib.parse.quote(j['alias'])}",
+                     token=a_token, body={})
+        log("[alice-redo] joined fresh lobby as existing member",
+            s2 == 200, f"status={s2}")
+
+        keyword = None
+        since = None
+        deadline = time.time() + 45
+        while time.time() < deadline:
+            url = "/_matrix/client/v3/sync?timeout=10000"
+            if since:
+                url += f"&since={urllib.parse.quote(since)}"
+            _s, sync = http("GET", url, token=a_token, timeout=15)
+            since = sync.get("next_batch") or since
+            joined = sync.get("rooms", {}).get("join", {}).get(redo_room, {})
+            for ev in joined.get("timeline", {}).get("events", []):
+                if ev.get("type") != "m.room.message":
+                    continue
+                body_text = (ev.get("content") or {}).get("body", "")
+                m = re.search(r'include the word "([^"]+)"', body_text)
+                if m:
+                    keyword = m.group(1)
+                    break
+            if keyword:
+                break
+            await asyncio.sleep(1)
+        log("[alice-redo] captcha keyword visible", bool(keyword),
+            f"keyword={keyword!r}")
+
+        if keyword:
+            haiku = (f"silent {keyword} hum\nfloating in the morning fog\n"
+                     f"spring wind blowing through")
+            http("PUT",
+                 f"/_matrix/client/v3/rooms/{urllib.parse.quote(redo_room)}"
+                 f"/send/m.room.message/e2e-redo-{int(time.time())}",
+                 token=a_token, body={"msgtype": "m.text", "body": haiku})
+
+            # Wait for the bot's "already in space" success ack.
+            ack = None
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                url = "/_matrix/client/v3/sync?timeout=10000"
+                if since:
+                    url += f"&since={urllib.parse.quote(since)}"
+                _s, sync = http("GET", url, token=a_token, timeout=15)
+                since = sync.get("next_batch") or since
+                joined = sync.get("rooms", {}).get("join", {}).get(redo_room, {})
+                for ev in joined.get("timeline", {}).get("events", []):
+                    if ev.get("type") != "m.room.message":
+                        continue
+                    b = (ev.get("content") or {}).get("body", "")
+                    if "already in shape rotator" in b.lower():
+                        ack = b
+                        break
+                if ack:
+                    break
+                await asyncio.sleep(1)
+            log("[alice-redo] got 'already in space' ack from bot",
+                bool(ack), f"ack={ack!r}")
+
     failed = [name for name, ok in results if not ok]
     print(f"\n=== {len(results) - len(failed)}/{len(results)} pass ===")
     if failed:


### PR DESCRIPTION
## Summary

When an existing space member re-runs the lobby flow as a debug self-test, the bot's invite-to-space POST returns 403 (user already in the room). Previously: logged 'lobby promote failed' and left the user stuck in the lobby with no ack. Now: treated as success — bot sends \"you're already in shape rotator — see you in the space.\", leaves the lobby room, marks closed_reason='already_member'.

## Why

@socrates1024 wants to be able to self-test the lobby+haiku flow as an existing space member without spinning up new accounts. The first lobby PR (#25) already let the code be consumed and the haiku posted, but the bot stalled at the promote step. This makes the path actually usable.

## Test plan

- [x] tests/lobby_e2e.py adds an [alice-redo] case after the existing two-user E2EE round-trip: alice (now a space member) re-runs /join/api → joins fresh lobby → posts haiku → asserts the bot's \"already in space\" ack arrives.
- [x] 23/23 pass, two consecutive clean local runs of bash tests/run_e2e.sh.