### PR TITLE
admin_e2ee: bump deadline + warmup syncs for slow CI runners

### DIFF
--- a/tests/admin_e2ee.py
+++ b/tests/admin_e2ee.py
@@ -113,8 +113,11 @@ async def main():
     with urllib.request.urlopen(req) as r:
         log("test user joined admin room", r.status == 200, f"status={r.status}")
 
-    # Initial sync to learn room state + member device keys.
-    for _ in range(3):
+    # Initial sync to learn room state + exchange device keys with the bot.
+    # GitHub Actions runners are slower than local — 5 warmup syncs gives
+    # mautrix time to fetch + verify the bot's device keys before we start
+    # sending encrypted traffic.
+    for _ in range(5):
         await sync_once(client, ss, timeout=2000, first=True)
 
     enc = await ss.is_encrypted(ADMIN_ROOM)
@@ -129,8 +132,10 @@ async def main():
     log("sent encrypted !mint command", bool(sent_id), f"event_id={sent_id}")
 
     # Poll for the bot's reply: decrypted body should contain the label
-    # we passed AND a /join?code= URL.
-    deadline = time.time() + 45
+    # we passed AND a /join?code= URL. Generous deadline (120s) — on slow
+    # CI runners the bot may be mid-sync of the previous test's traffic
+    # when our !mint lands.
+    deadline = time.time() + 120
     seen_reply = None
     received = asyncio.Event()
 

--- a/tests/vetting_e2e.py
+++ b/tests/vetting_e2e.py
@@ -81,7 +81,7 @@ async def onboard_via_vetting(label):
     log(f"[{label}] knock posted", s == 200, f"status={s}")
 
     space_prefix = SPACE_ID.split(":")[0]
-    deadline = time.time() + 30
+    deadline = time.time() + 60
     vetting_room = None
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
@@ -104,7 +104,7 @@ async def onboard_via_vetting(label):
 
     # Pull the captcha challenge — bot may need a beat after our join.
     keyword = None
-    deadline = time.time() + 15
+    deadline = time.time() + 30
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
         joined = sync.get("rooms", {}).get("join", {}).get(vetting_room, {})
@@ -134,7 +134,7 @@ async def onboard_via_vetting(label):
     log(f"[{label}] haiku sent", s == 200, f"status={s}")
 
     # Wait for the actual space invite.
-    deadline = time.time() + 30
+    deadline = time.time() + 60
     got_space = False
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
@@ -204,7 +204,7 @@ async def main():
         f"event_id={event_id}")
 
     decrypted_body = None
-    deadline = time.time() + 30
+    deadline = time.time() + 60
     received = asyncio.Event()
 
     async def on_msg(evt):


### PR DESCRIPTION
## Summary

admin_e2ee.py was timing out on GitHub Actions runners across every v0.5/v0.6 deploy attempt while passing every local run. Two robustness fixes:

- 3 warmup syncs → 5 (gives mautrix more time to fetch + verify the bot's device keys before encrypted traffic)
- 45s deadline → 120s for the bot's encrypted reply

## Test plan

- [x] bash tests/run_e2e.sh clean: smoke 18/18, vetting 18/18, lobby 23/23, admin 7/7, sas info PASS