### PR TITLE
docker-compose: add pycryptodome to approver pip install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     command: >
       sh -c '
       apt-get update -qq && apt-get install -y --no-install-recommends -qq libolm3 libolm-dev gcc &&
-      pip install --quiet aiohttp cryptography mautrix asyncpg aiosqlite python-olm unpaddedbase64 base58 pyaes &&
+      pip install --quiet aiohttp cryptography mautrix asyncpg aiosqlite python-olm unpaddedbase64 base58 pyaes pycryptodome &&
       echo "$$APPROVER_B64" | base64 -d > /app.py &&
       exec python -u /app.py
       '


### PR DESCRIPTION
Hot-fix. Production approver crash-looping after v0.7 deploy:

\`\`\`
ModuleNotFoundError: No module named 'Cryptodome'
\`\`\`

mautrix needs pycryptodome for cross-signing helpers. PR #22's pip install missed it. Test stack passed because test image has it baked; prod uses inline pip install.