### PR TITLE
auto-mint a 10-use signup code on lobby/vetting promotion

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -171,6 +171,11 @@ LOBBY_MAX_RESENDS     = 1
 # code so the new member can register accounts/agents on this server
 # without having to ping an admin. 0 disables the feature.
 LOBBY_WELCOME_CODE_USES = int(os.environ.get("LOBBY_WELCOME_CODE_USES", "10"))
+# Optional onboarding doc link, posted alongside the welcome signup code.
+LOBBY_WELCOME_DOC_URL = os.environ.get(
+    "LOBBY_WELCOME_DOC_URL",
+    "https://github.com/amiller/smithers-toys/blob/main/demos/shape-rotator-matrix-welcome.md",
+).strip()
 LOBBY_ALIAS_PREFIX = os.environ.get("LOBBY_ALIAS_PREFIX", "shape-rotator-lobby-")
 # Server name for room aliases. May be overridden by env; otherwise resolved
 # at startup from /whoami (parsing the homeserver's view of OUR_MXID).
@@ -469,6 +474,8 @@ async def process_vetting_room(client, room_id, meta, join_ev, msgs):
                 meta["invited_children"] = invited_children
                 signup_code, signup_url = _mint_welcome_signup_code(meta["mxid"])
                 ack = "nice — invited you to shape rotator. you can leave this room."
+                if LOBBY_WELCOME_DOC_URL:
+                    ack += f"\n\nonboarding doc: {LOBBY_WELCOME_DOC_URL}"
                 if signup_url:
                     ack += (f"\n\nhere's a {LOBBY_WELCOME_CODE_USES}-use signup "
                             f"code for adding accounts/agents to this server: "
@@ -756,6 +763,8 @@ async def process_lobby_room(room_id, meta, new_joins, msgs, lobby_mxid):
                 ack = ("you're already in shape rotator — see you in the space."
                        if already_member else
                        "nice — invited you to shape rotator. see you in the space.")
+                if LOBBY_WELCOME_DOC_URL:
+                    ack += f"\n\nonboarding doc: {LOBBY_WELCOME_DOC_URL}"
                 if signup_url:
                     ack += (f"\n\nhere's a {LOBBY_WELCOME_CODE_USES}-use signup "
                             f"code for adding accounts/agents to this server: "

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -167,6 +167,10 @@ LOBBY_MAX_TRIES    = int(os.environ.get("LOBBY_MAX_TRIES",    "3"))
 LOBBY_CHALLENGE_DELAY = int(os.environ.get("LOBBY_CHALLENGE_DELAY_SEC", "5"))
 LOBBY_RESEND_AFTER    = int(os.environ.get("LOBBY_RESEND_AFTER_SEC", "120"))
 LOBBY_MAX_RESENDS     = 1
+# After successful promotion (lobby OR vetting), mint a multi-use signup
+# code so the new member can register accounts/agents on this server
+# without having to ping an admin. 0 disables the feature.
+LOBBY_WELCOME_CODE_USES = int(os.environ.get("LOBBY_WELCOME_CODE_USES", "10"))
 LOBBY_ALIAS_PREFIX = os.environ.get("LOBBY_ALIAS_PREFIX", "shape-rotator-lobby-")
 # Server name for room aliases. May be overridden by env; otherwise resolved
 # at startup from /whoami (parsing the homeserver's view of OUR_MXID).
@@ -270,6 +274,29 @@ async def _invite_to_children(mxid):
             print(f"[lobby] child {child} invite of {mxid} -> {st}: {body[:200]}",
                   flush=True)
     return invited
+
+
+def _mint_welcome_signup_code(mxid):
+    """Mint a fresh signup code labeled with mxid, persist to SIGNUP_PATH,
+    and return (code, url). Returns (None, None) if disabled (uses=0).
+
+    Same write surface as cmd_mint, but minted by the bot itself on
+    successful airlock promotion so the member can self-onboard their
+    agents without pinging an admin.
+    """
+    if LOBBY_WELCOME_CODE_USES <= 0:
+        return None, None
+    codes = _load(SIGNUP_PATH)
+    code = _new_code()
+    while code in codes:
+        code = _new_code() + secrets.token_hex(2)
+    codes[code] = {
+        "uses_remaining": LOBBY_WELCOME_CODE_USES,
+        "label": f"welcome:{mxid}",
+        "inviter": mxid,
+    }
+    _save(SIGNUP_PATH, codes)
+    return code, f"{HS_PUBLIC}/signup?code={code}"
 
 
 async def _lobby_leave_room(room_id, reason="lobby done"):
@@ -440,8 +467,13 @@ async def process_vetting_room(client, room_id, meta, join_ev, msgs):
                 meta["displayname"] = displayname
                 invited_children = await _invite_to_children(meta["mxid"])
                 meta["invited_children"] = invited_children
-                await _send_msg(client, room_id,
-                    "nice — invited you to shape rotator. you can leave this room.")
+                signup_code, signup_url = _mint_welcome_signup_code(meta["mxid"])
+                ack = "nice — invited you to shape rotator. you can leave this room."
+                if signup_url:
+                    ack += (f"\n\nhere's a {LOBBY_WELCOME_CODE_USES}-use signup "
+                            f"code for adding accounts/agents to this server: "
+                            f"{signup_url}")
+                await _send_msg(client, room_id, ack)
                 # Relay the captcha + haiku to FEED_ROOM so the rest of
                 # the community sees who joined and gets to enjoy their
                 # haiku. send_message_event auto-encrypts if FEED_ROOM is E2EE.
@@ -457,7 +489,8 @@ async def process_vetting_room(client, room_id, meta, join_ev, msgs):
                 audit({"type": "promoted", "user": meta["mxid"],
                        "displayname": displayname, "room": room_id,
                        "haiku": text, "title": meta.get("title"),
-                       "keyword": meta.get("keyword")})
+                       "keyword": meta.get("keyword"),
+                       "welcome_signup_code": signup_code})
                 print(f"[promoted] {meta['mxid']} ({displayname})", flush=True)
             else:
                 audit({"type": "promote_failed", "user": meta["mxid"],
@@ -719,9 +752,14 @@ async def process_lobby_room(room_id, meta, new_joins, msgs, lobby_mxid):
                 meta["promoted_at"] = time.time()
                 meta["promoted_user"] = mxid
                 invited_children = await _invite_to_children(mxid)
+                signup_code, signup_url = _mint_welcome_signup_code(mxid)
                 ack = ("you're already in shape rotator — see you in the space."
                        if already_member else
                        "nice — invited you to shape rotator. see you in the space.")
+                if signup_url:
+                    ack += (f"\n\nhere's a {LOBBY_WELCOME_CODE_USES}-use signup "
+                            f"code for adding accounts/agents to this server: "
+                            f"{signup_url}")
                 await _send_msg_raw(room_id, ack)
                 # FEED_ROOM relay (haiku celebration to #matrix-devops) is
                 # the main bot's job, not the lobby bot's — it lives in a
@@ -730,7 +768,8 @@ async def process_lobby_room(room_id, meta, new_joins, msgs, lobby_mxid):
                 audit({"type": "lobby_promoted", "user": mxid, "room": room_id,
                        "haiku": text, "title": title, "keyword": keyword,
                        "already_member": already_member,
-                       "invited_children": invited_children})
+                       "invited_children": invited_children,
+                       "welcome_signup_code": signup_code})
                 print(f"[lobby promoted] {mxid} ({displayname})"
                       f"{' (already in space)' if already_member else ''}"
                       f" children={len(invited_children)}/{len(SPACE_CHILD_IDS)}",

--- a/tests/lobby_e2e.py
+++ b/tests/lobby_e2e.py
@@ -132,18 +132,32 @@ async def onboard_via_lobby(label):
         token=token, body={"msgtype": "m.text", "body": haiku})
     log(f"[{label}] haiku sent", s == 200, f"status={s}")
 
-    # Wait for the actual space invite.
+    # Wait for the actual space invite. Also collect any new lobby-room
+    # messages so we can assert the bot posts a signup-code URL on success.
     space_prefix = SPACE_ID.split(":")[0]
     deadline = time.time() + 30
     got_space = False
+    signup_url = None
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
         if any(rid.split(":")[0] == space_prefix
                for rid in sync.get("rooms", {}).get("invite", {}).keys()):
             got_space = True
+        for ev in (sync.get("rooms", {}).get("join", {})
+                   .get(lobby_room, {}).get("timeline", {})
+                   .get("events", [])):
+            if ev.get("type") != "m.room.message":
+                continue
+            body = (ev.get("content") or {}).get("body", "")
+            m = re.search(r"https?://\S+/signup\?code=\S+", body)
+            if m:
+                signup_url = m.group(0)
+        if got_space and signup_url:
             break
         await asyncio.sleep(1)
     log(f"[{label}] space invite after lobby", got_space)
+    log(f"[{label}] welcome signup-code url posted in ack",
+        bool(signup_url), f"url={signup_url}")
     if not got_space:
         return None
 

--- a/tests/lobby_e2e.py
+++ b/tests/lobby_e2e.py
@@ -138,6 +138,7 @@ async def onboard_via_lobby(label):
     deadline = time.time() + 30
     got_space = False
     signup_url = None
+    saw_doc = False
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
         if any(rid.split(":")[0] == space_prefix
@@ -152,12 +153,15 @@ async def onboard_via_lobby(label):
             m = re.search(r"https?://\S+/signup\?code=\S+", body)
             if m:
                 signup_url = m.group(0)
-        if got_space and signup_url:
+            if "onboarding doc:" in body.lower():
+                saw_doc = True
+        if got_space and signup_url and saw_doc:
             break
         await asyncio.sleep(1)
     log(f"[{label}] space invite after lobby", got_space)
     log(f"[{label}] welcome signup-code url posted in ack",
         bool(signup_url), f"url={signup_url}")
+    log(f"[{label}] onboarding doc url posted in ack", saw_doc)
     if not got_space:
         return None
 

--- a/tests/vetting_e2e.py
+++ b/tests/vetting_e2e.py
@@ -138,6 +138,7 @@ async def onboard_via_vetting(label):
     deadline = time.time() + 60
     got_space = False
     signup_url = None
+    saw_doc = False
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
         if any(rid.split(":")[0] == space_prefix
@@ -152,12 +153,15 @@ async def onboard_via_vetting(label):
             m = re.search(r"https?://\S+/signup\?code=\S+", body)
             if m:
                 signup_url = m.group(0)
-        if got_space and signup_url:
+            if "onboarding doc:" in body.lower():
+                saw_doc = True
+        if got_space and signup_url and saw_doc:
             break
         await asyncio.sleep(1)
     log(f"[{label}] space invite after vetting", got_space)
     log(f"[{label}] welcome signup-code url posted in ack",
         bool(signup_url), f"url={signup_url}")
+    log(f"[{label}] onboarding doc url posted in ack", saw_doc)
     if not got_space:
         return None
 

--- a/tests/vetting_e2e.py
+++ b/tests/vetting_e2e.py
@@ -133,17 +133,31 @@ async def onboard_via_vetting(label):
         token=token, body={"msgtype": "m.text", "body": haiku})
     log(f"[{label}] haiku sent", s == 200, f"status={s}")
 
-    # Wait for the actual space invite.
+    # Wait for the actual space invite. Also collect any vetting-room
+    # messages so we can assert the bot posts a signup-code URL on success.
     deadline = time.time() + 60
     got_space = False
+    signup_url = None
     while time.time() < deadline:
         _s, sync = http("GET", "/_matrix/client/v3/sync?timeout=0", token=token)
         if any(rid.split(":")[0] == space_prefix
                for rid in sync.get("rooms", {}).get("invite", {}).keys()):
             got_space = True
+        for ev in (sync.get("rooms", {}).get("join", {})
+                   .get(vetting_room, {}).get("timeline", {})
+                   .get("events", [])):
+            if ev.get("type") != "m.room.message":
+                continue
+            body = (ev.get("content") or {}).get("body", "")
+            m = re.search(r"https?://\S+/signup\?code=\S+", body)
+            if m:
+                signup_url = m.group(0)
+        if got_space and signup_url:
             break
         await asyncio.sleep(1)
     log(f"[{label}] space invite after vetting", got_space)
+    log(f"[{label}] welcome signup-code url posted in ack",
+        bool(signup_url), f"url={signup_url}")
     if not got_space:
         return None
 


### PR DESCRIPTION
Closes #32.

## Summary

After a user passes the lobby (or vetting) airlock, mint a fresh multi-use signup code and post the `/signup?code=…` link in the airlock room as part of the "you're in" ack. The airlock room is effectively a 1:1 with the user, so this is a free DM — no extra createRoom needed.

- New env var `LOBBY_WELCOME_CODE_USES` (default `10`, set to `0` to disable)
- New helper `_mint_welcome_signup_code(mxid)` — same write surface as `cmd_mint`
- Wired into both `process_lobby_room` and `process_vetting_room` success paths
- Audit log gains a `welcome_signup_code` field on `lobby_promoted` / `promoted` events
- e2e suites assert the URL is present in both flows (lobby + vetting + the existing-member redo path)

## Test plan

- [x] `bash tests/run_e2e.sh` locally — `smoke 18/18`, `vetting_e2e 20/20`, `lobby_e2e 25/25` all pass with the new welcome-code assertions
- [x] One pre-existing failure: `admin_e2ee` `bot replied with encrypted !mint result` (5/6) — this is the same megolm flake that failed in [the last main CI run on 2026-05-05](https://github.com/teleport-computer/shape-rotator-matrix/actions/runs/25356402707). Not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)