### PR TITLE
approver: fix self-heal cached-token + crypto-wipe bugs surfaced by PR #37 deploy

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -1966,9 +1966,9 @@ async def main():
 
     # Self-heal @shape-rotator-2 (main bot). Tries env token, then cached
     # /data token, then password /login (with cached device_id so the
-    # crypto store stays valid across re-mints). Only wipes crypto when
-    # the device_id actually changed — usually only on first run with
-    # existing /data, or after a true device rotation.
+    # crypto store stays valid across re-mints).
+    sr2_cached_device_before = _read_text(SR2_DEVICE_ID_PATH)
+    sr2_crypto_existed_before = CRYPTO_DB.exists()
     sr2_token, _sr2_device, sr2_mxid, sr2_reminted, sr2_device_changed = \
         await _resolve_credentials(
             TOKEN, "shape-rotator-2", SR2_PASSWORD_PATH,
@@ -1978,23 +1978,29 @@ async def main():
             "fatal: cannot authenticate as @shape-rotator-2. "
             "Either MATRIX_TOKEN is unset/invalid AND no password is "
             f"persisted at {SR2_PASSWORD_PATH}.")
-    if sr2_reminted:
-        TOKEN = sr2_token
-        AUTH = {"Authorization": f"Bearer {TOKEN}"}
-    if sr2_device_changed:
+    # Always wire the resolved token in — env_token-success path returns
+    # reminted=False but still gives back the working token, which may
+    # differ from the (possibly-stale) os.environ["MATRIX_TOKEN"] global.
+    TOKEN = sr2_token
+    AUTH = {"Authorization": f"Bearer {TOKEN}"}
+    # Wipe crypto if the device_id rotated (caught by _device_changed) OR
+    # if we just minted fresh against an existing crypto.db that has no
+    # cached device_id alongside it (transition case: pre-PR-#37 deploy
+    # left a stale pickle for an unknown device).
+    if sr2_device_changed or (
+            sr2_reminted and not sr2_cached_device_before and sr2_crypto_existed_before):
         _wipe_crypto_store()
 
     # Self-heal @onboarding-bot (lobby flow). Same shape; no crypto wipe
     # because the lobby sync loop is cleartext.
     if LOBBY_TOKEN != sr2_token:  # only when a dedicated lobby bot is configured
-        lobby_token, _, _, lobby_reminted, _ = await _resolve_credentials(
+        lobby_token, _, _, _lobby_reminted, _ = await _resolve_credentials(
             LOBBY_TOKEN, "onboarding-bot", ONBOARDING_BOT_PASSWORD_PATH,
             ONBOARDING_BOT_TOKEN_PATH, ONBOARDING_BOT_DEVICE_ID_PATH,
             "onboarding-bot")
         if lobby_token:
-            if lobby_reminted:
-                LOBBY_TOKEN = lobby_token
-                LOBBY_AUTH = {"Authorization": f"Bearer {LOBBY_TOKEN}"}
+            LOBBY_TOKEN = lobby_token
+            LOBBY_AUTH = {"Authorization": f"Bearer {LOBBY_TOKEN}"}
         else:
             print("[self-heal] onboarding-bot auth failed; lobby flow disabled",
                   flush=True)


### PR DESCRIPTION
## Summary
Two follow-on bugs from PR #37 surfaced by the first deploy on prod tonight. Both fired in the transition case (existing bot_crypto.db + no cached token files yet).

### Bug 1: cached-token path doesn't update TOKEN
\`_resolve_credentials\` returns a cached token with \`reminted=False\`. main() previously only assigned \`TOKEN = sr2_token\` when \`reminted=True\`. So the cached path returned a working token but main left the global \`TOKEN\` pointing at the (stale) \`os.environ["MATRIX_TOKEN"]\`. Mautrix client constructed with the stale value → /sync failed with M_UNKNOWN_TOKEN.

Fix: assign \`TOKEN = sr2_token\` and \`AUTH\` unconditionally after self-heal returns. Same for \`LOBBY_TOKEN\` / \`LOBBY_AUTH\`.

### Bug 2: crypto wipe missed on first PR-#37 boot
The first PR-#37 boot finds \`/data/bot_crypto.db\` present but no \`/data/<bot>_device_id\` yet (PR #37's persistence hasn't run). \`_login_with_password\` runs without device_id, gets a fresh device. \`_device_changed(None, NEW) = False\` → no wipe. Mautrix then tries to load crypto.db with pickle_key for the new device, which doesn't match the prior device's pickle → \`OlmAccountError: BAD_ACCOUNT_KEY\` → bot crashes at startup.

Fix: in main(), capture \`cached_device_before\` and \`crypto_existed_before\` BEFORE \`_resolve_credentials\` writes to disk. Wipe crypto when:
- \`device_id\` rotated (existing \`_device_changed\` logic), OR  
- \`reminted=True\` AND no prior cached device AND crypto.db exists (the transition case).

## Test plan
- [x] \`python3 tests/self_heal_unit.py\` — all 7 existing tests still pass.
- [x] \`python3 tests/announce_unit.py\` — still passes.
- [ ] e2e CI on this branch.
- [ ] Verify via prod deploy after merge — bot should restart cleanly without manual \`rm /data/bot_crypto.db*\` intervention.

## Manual recovery executed before this fix
Tonight on prod (2026-05-09 ~19:50 UTC) the bot crash-looped on BAD_ACCOUNT_KEY after the first PR-#37 deploy. Workaround: \`rm /data/bot_crypto.db* /data/<bot>_token /data/<bot>_device_id\` then \`docker restart\` — bot did the full self-heal cycle from scratch and recovered. This PR removes that manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)