### PR TITLE
approver: silence ⚠️ timeout for lobby rooms nobody joined

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -1407,7 +1407,14 @@ async def announce_lobby_events(client):
             dirty = True
         if (meta.get("closed") and not rec["failed"]
                 and meta.get("closed_reason") not in (None, "promoted", "already_member")):
-            users = ", ".join(meta.get("challenged", []) or ["(no users joined)"])
+            if meta.get("closed_reason") == "timeout" and not meta.get("challenged"):
+                # Ghost room: link-preview bots and aborted clicks mint a
+                # /join/api room but never produce a real join. Mark seen
+                # so we don't re-evaluate, but don't notify.
+                rec["failed"] = True
+                dirty = True
+                continue
+            users = ", ".join(meta["challenged"])
             await _send_msg(client, OPERATOR_NOTIFY_ROOM,
                 f"⚠️ lobby failed for {users} "
                 f"(reason={meta.get('closed_reason')}, code={meta.get('code', '?')})")

--- a/tests/announce_unit.py
+++ b/tests/announce_unit.py
@@ -120,6 +120,49 @@ def test_seen_persists_across_cycles_for_open_then_closed():
     assert len(sends) == 2, f"expected exactly 2 sends total (🚪 + ⚠️), got {len(sends)}: {sends}"
 
 
+def test_ghost_timeout_suppressed_but_real_timeout_announced():
+    """A timeout with empty `challenged` is a link-preview bot / aborted
+    click and must not fire ⚠️. A timeout where a user actually joined
+    but never completed the haiku still fires."""
+    sends = _install_send_recorder()
+    # Phase 1: both rooms open. !real has a challenged user (joined +
+    # got the haiku), !ghost has nobody (link-preview / aborted click).
+    lobby = {
+        "!ghost:t": {"code": "abc", "challenged": [], "displaynames": {},
+                     "closed": False},
+        "!real:t":  {"code": "abc", "challenged": ["@u:t"],
+                     "displaynames": {"@u:t": "u"}, "closed": False},
+    }
+    approver._save(approver.LOBBY_PATH, lobby)
+    approver._save(approver.OPERATOR_ANNOUNCE_PATH,
+                   {"!seed:t": {"started": [], "failed": False}})
+
+    client = MagicMock()
+    asyncio.run(approver.announce_lobby_events(client))
+    started_msgs = [t for _r, t in sends if "started lobby flow" in t]
+    assert len(started_msgs) == 1, f"expected 1 🚪 in phase 1, got {sends}"
+
+    # Phase 2: both time out. Ghost still has no challenged users.
+    sends.clear()
+    for rid in ("!ghost:t", "!real:t"):
+        lobby[rid]["closed"] = True
+        lobby[rid]["closed_reason"] = "timeout"
+    approver._save(approver.LOBBY_PATH, lobby)
+
+    asyncio.run(approver.announce_lobby_events(client))
+    asyncio.run(approver.announce_lobby_events(client))
+
+    failed_msgs = [t for _r, t in sends if "lobby failed for" in t]
+    assert len(failed_msgs) == 1, f"expected 1 ⚠️ (real only), got {sends}"
+    assert "@u:t" in failed_msgs[0], f"⚠️ should name the real user, got {failed_msgs[0]}"
+    assert "(no users joined)" not in " ".join(t for _r, t in sends), \
+        f"ghost timeout must not fire (no users joined) message: {sends}"
+
+    seen = json.loads(approver.OPERATOR_ANNOUNCE_PATH.read_text())
+    assert seen["!ghost:t"]["failed"] is True, \
+        "ghost room must be marked failed so we don't re-evaluate"
+
+
 if __name__ == "__main__":
     test_no_flood_on_historical_closed_rooms()
     print("ok: no_flood_on_historical_closed_rooms")
@@ -127,4 +170,6 @@ if __name__ == "__main__":
     print("ok: open_room_still_announced")
     test_seen_persists_across_cycles_for_open_then_closed()
     print("ok: seen_persists_across_cycles_for_open_then_closed")
+    test_ghost_timeout_suppressed_but_real_timeout_announced()
+    print("ok: ghost_timeout_suppressed_but_real_timeout_announced")
     print("all tests passed")


### PR DESCRIPTION
## Summary
- The shared-code lobby flow (one signup code, many uses) gets opened by link-preview bots, accidental reloads, and aborted clicks. Each hits `/join/api`, which mints a fresh public room with `challenged=[]`. 2h later the cleanup sweeper closes those rooms with `closed_reason="timeout"` and the operator notify room sees a `⚠️ lobby failed for (no users joined)` for every one of them — clusters of 3+ around each actual signup.
- This PR suppresses the announcement for timeout closures with empty `challenged`, marks the room as seen so the announce loop doesn't re-evaluate it forever, and keeps firing for the actionable bucket (user joined, never completed the haiku).
- No state-file format changes. Existing seen-records keep working. Safe to apply during low-traffic window — no service restart needed beyond the usual approver container restart.

## Test plan
- [x] `python3 tests/announce_unit.py` — all four tests pass, including the new `test_ghost_timeout_suppressed_but_real_timeout_announced` which models open→timeout transition with one ghost room and one room where a user actually joined.
- [x] Existing tests (`test_no_flood_on_historical_closed_rooms`, `test_open_room_still_announced`, `test_seen_persists_across_cycles_for_open_then_closed`) still pass.
- [ ] After deploy: confirm no `⚠️ lobby failed for (no users joined)` messages appear in the operator notify room over a 24h window.
- [ ] Confirm a deliberately-failed lobby (join + skip haiku for 2h) still fires `⚠️ lobby failed for @user:server (reason=timeout, code=…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)