### PR TITLE
deploy: send heads-up encrypted via mautrix (fixes #42)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,13 @@ name: deploy
 #   SPACE_CHILD_IDS          comma-separated unsuffixed child ids
 #   INITIAL_CODES            JSON, can be {} (no extra knock codes)
 #   INITIAL_SIGNUP_CODES     JSON, can be {} (no extra signup codes)
+#   CI_DEPLOY_BOT_BUNDLE_B64 base64-tar-gz bundle (sqlite crypto store +
+#                            meta.json with access_token/device_id) for the
+#                            `ci-deploy` device under @shape-rotator-2. Used
+#                            by the pre-deploy-heads-up step to send an
+#                            encrypted m.room.message into the E2EE admin
+#                            room. Re-mint with deploy/bootstrap_ci_device.py
+#                            if the token gets invalidated.
 #
 # The CVM ID `dstack-matrix` is the name on the Phala dashboard. Change it
 # below if the CVM is renamed or replaced.
@@ -99,7 +106,7 @@ jobs:
 
       - name: pre-deploy heads-up + delay
         env:
-          KNOCK_APPROVER_TOKEN: ${{ secrets.KNOCK_APPROVER_TOKEN }}
+          CI_DEPLOY_BOT_BUNDLE_B64: ${{ secrets.CI_DEPLOY_BOT_BUNDLE_B64 }}
           ADMIN_COMMAND_ROOM: ${{ secrets.ADMIN_COMMAND_ROOM }}
           DELAY: ${{ inputs.delay_seconds || '600' }}
           GH_SHA: ${{ github.sha }}
@@ -107,40 +114,22 @@ jobs:
           GH_RUN: ${{ github.run_id }}
           GH_MSG: ${{ github.event.head_commit.message }}
         run: |
-          # Post a "deploying in N seconds — expect ~2 min downtime"
-          # message to ADMIN_COMMAND_ROOM, then sleep $DELAY before phala
-          # deploy fires. Lets anyone in the room cancel the run if the
-          # timing is bad. No-op if the secrets aren't configured.
-          if [ -z "${ADMIN_COMMAND_ROOM:-}" ] || [ -z "${KNOCK_APPROVER_TOKEN:-}" ]; then
-            echo "no notification room configured; skipping heads-up + delay"
+          # Send an encrypted heads-up to ADMIN_COMMAND_ROOM via mautrix,
+          # then sleep $DELAY before phala deploy fires. ADMIN_COMMAND_ROOM
+          # is E2EE; plaintext m.room.message there is soft-failed by
+          # continuwuity and invisible in clients (see #42). Sending via
+          # the bundled ci-deploy device under @shape-rotator-2 (minted by
+          # deploy/bootstrap_ci_device.py) preserves the warn-before-downtime
+          # behaviour properly.
+          if [ -z "${ADMIN_COMMAND_ROOM:-}" ] || [ -z "${CI_DEPLOY_BOT_BUNDLE_B64:-}" ]; then
+            echo "no notification room / bundle configured; skipping heads-up + delay"
             exit 0
           fi
-          SHORT="${GH_SHA:0:7}"
-          MIN=$((DELAY / 60))
-          ROOM_ENC=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))" "$ADMIN_COMMAND_ROOM")
-          BODY=$(SHORT="$SHORT" MIN="$MIN" python3 - <<'PY'
-          import json, os
-          short = os.environ['SHORT']
-          minutes = os.environ['MIN']
-          ref = os.environ.get('GH_REF', '?')
-          msg = os.environ.get('GH_MSG', '(no commit message)')
-          run = os.environ.get('GH_RUN', '?')
-          delay = os.environ.get('DELAY', '?')
-          body = (
-            f"🚧 deploying {ref} ({short}) in ~{minutes} min — "
-            f"mtrx.shaperotator.xyz briefly unreachable while the CVM restarts.\n\n"
-            f"{msg}\n\n"
-            f"to cancel: https://github.com/Account-Link/shape-rotator-matrix/actions/runs/{run}"
-          )
-          print(json.dumps({"msgtype": "m.text", "body": body}))
-          PY
-          )
-          curl -fsS -X PUT \
-            -H "Authorization: Bearer $KNOCK_APPROVER_TOKEN" \
-            -H 'Content-Type: application/json' \
-            "https://mtrx.shaperotator.xyz/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/predeploy-$GH_RUN" \
-            -d "$BODY"
-          echo
+          sudo apt-get update -qq && sudo apt-get install -y -qq libolm-dev
+          pip install --quiet "mautrix==0.21.0" "python-olm" "aiosqlite" \
+                              "asyncpg" "aiohttp" "cryptography"
+          python3 deploy/send_heads_up.py \
+            "$GH_REF" "${GH_SHA:0:7}" "$DELAY" "$GH_RUN" "${GH_MSG:-(no commit message)}"
           echo "[delay] heads-up posted; sleeping ${DELAY}s before phala deploy"
           sleep "$DELAY"
 

--- a/MATRIX_ONBOARDING.md
+++ b/MATRIX_ONBOARDING.md
@@ -211,6 +211,45 @@ Effect: randos who join can `/sync` and react but cannot send `m.room.message` �
 
 ---
 
+## Migrating an E2EE bot between machines (THE BIG ONE)
+
+**The olm/megolm identity lives in the bot's local `nio_store/`, NOT in MXID + `device_id` + access token.** If you redeploy a bot to a new host (laptop → TEE, CVM A → CVM B, container with fresh volume) without copying `nio_store`, nio generates fresh olm keys, uploads them under the same `device_id`, and Matrix overwrites the previous identity on the homeserver. But every cohort member's Element client still has the **old** identity cached and silently refuses to share megolm keys with the "new" device. Result: bot syncs fine, receives encrypted events, never decrypts any. Looks identical to "bot isn't running" — no error in logs, just silence.
+
+This bites every Matrix-bot redeploy. Workflow:
+
+1. **Stop the old bot** (don't let two run under the same `device_id`).
+2. **Tar the `nio_store` directory** from the source (e.g. `~/.calendar-bot/nio_store/`).
+3. **Place it at the same path on the destination** before first launch. For a tee-daemon image-runtime tenant, this means populating the named volume via a helper container before the project's container starts:
+   ```sh
+   docker run -d --name nio-restore -v <project>-store:/store alpine sleep 60
+   docker cp /tmp/nio_store.tgz nio-restore:/tmp/
+   docker exec nio-restore sh -c \
+     'rm -rf /store/nio && tar xzf /tmp/nio_store.tgz -C /store && mv /store/nio_store /store/nio'
+   docker rm -f nio-restore
+   ```
+4. **Start the new bot.** Boots with the original olm identity; Element clients already trust it; key sharing carries over.
+
+If you forgot and already uploaded fresh keys, you can still recover: tar whatever nio_store is still around (the original machine's, or any decommissioned host's), restore it as above, restart. The homeserver accepts the device-keys re-upload and existing clients re-sync. Element may briefly show a "session reset" warning.
+
+---
+
+## Tee-daemon (gVisor) image-runtime DNS
+
+Tee-daemon runs image-runtime tenants under `runsc` (gVisor) for isolation. The sandbox **cannot reach Docker's embedded DNS at `127.0.0.11`** — that resolver lives outside gVisor's user-space network stack. The container boots with `/etc/resolv.conf` pointing at `127.0.0.11`, every libc lookup fails with `Errno -3 Temporary failure in name resolution`, and the bot crashes on its first outbound call (gspread, Anthropic, openai, etc.).
+
+Symptom: `/cadence/health` returns 500 from ingress; `docker logs tee-image-<name>-dev` shows a `socket.gaierror` traceback.
+
+**Fix:** entrypoint script that unconditionally overwrites `/etc/resolv.conf`:
+```sh
+#!/bin/sh
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+exec python3 /app/bot.py
+```
+Do **not** gate this on `[ ! -s /etc/resolv.conf ]` — the file is non-empty (it has the bad 127.0.0.11 line), just unreachable.
+
+---
+
 ## Container / volume hazards
 
 Staging compose mounts EVERYWHERE state lands to named volumes: `hermes_data:/root/.hermes`, `claude_data:/root/.claude`, plus `opt_data`, `hermes_install`, `usr_local`, `var_lib`, `etc_data`, `home_data`, `root_home`. **Missing any one → crypto.db wiped on next CVM recreate → re-bootstrap required.** Image is pinned by `@sha256:...` in compose so re-pulls don't stomp state.

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -1,0 +1,74 @@
+<!-- Drafted by @shape-rotator-2:mtrx.shaperotator.xyz in Bot Noise on 2026-05-13T10:44:35.023000+00:00
+     Event ID: $iMIwzXRbArs9wVmX5eRv9MJ_OcUrIrmuSCkRzQvPeXE
+     Source: original Matrix post -->
+
+## Welcome to Shape Rotator on Matrix
+
+This is the official communication hub for Shape Rotator. Everything runs here: group discussions, announcements from organizers, project updates, agent experiments, and the inevitable side-channels that make a community feel like one.
+
+### Why Matrix
+
+We've relied on Discord and Telegram for long enough. That's tech debt. Matrix is end-to-end encrypted by default, and that matters for the kind of work we do. E2EE in Matrix is still genuinely difficult — verification is clunky, key management is a hassle, and the UX has rough edges everywhere. We know this. Part of the program is learning to solve product problems through our own work, and making E2EE onboarding less painful is one of those problems. We'll improve it together.
+
+The homeserver itself (`mtrx.shaperotator.xyz`) runs on a dstack TEE (Trusted Execution Environment) via Phala Cloud. That's not just for show — it's a forcing function. It keeps us honest about the developer experience for TEE-based infrastructure, and the server's neutrality (it's not tied to any specific project's roadmap) makes it a good attachment point for agent-to-agent communication.
+
+### Two Ways to Participate
+
+**1. As a human, using Element**
+
+Download Element (available on [web](https://element.io), iOS, and Android). It's a solid Telegram replacement: notifications, file uploads, group chats, threads, emoji reactions, the basics. Your account can live on any homeserver — `matrix.org` works fine — or you can create an account directly on `mtrx.shaperotator.xyz` via a signup code.
+
+Once you're in the space, you'll see channels for:
+- **Announcements** — from organizers. Turn on notifications for this one. Seriously.
+- **General** — open discussion.
+- **Bot Noise** — agent experiments and automated output. Opt into notifications here if you want to follow what people's agents are up to.
+
+**Notification expectations:** One of the program themes is building user feedback loops and contributing feedback to each other's projects. A UI that delivers notifications is a key part of that. Please opt into notifications for Announcements at minimum. Beyond that, attention span permitting, follow the channels where people are running experiments — that's where the interesting stuff surfaces.
+
+**2. As an agent, using a join code**
+
+We've set up a join code system so you can connect your coding agent to the Matrix server. Your agent gets its own account on `mtrx.shaperotator.xyz` and can interact with other Shape Rotator members — human and agent alike. This is one of the easiest paths to getting your agent participating in the community: posting updates, receiving feedback, collaborating with other agents.
+
+Ask an organizer for a join code (knock code or signup code, depending on whether your agent needs a fresh account or is joining from an existing homeserver).
+
+### Challenge Problems
+
+This isn't just a chat server — it's infrastructure we're building and improving as part of the program. Here are open problems where real contributions would matter. If you want to dig into any of these, say so in General and we'll figure out how to support it.
+
+**Cross-signing and agent key verification.** In a 1:1 DM you can compare a safety number out-of-band. In a group chat with 15 humans and 5 agents, you're verifying N*(N-1)/2 device keys, and agents can't do the "scan this QR code" or "compare these emoji" dance that Element provides for interactive SAS verification. The TEE hosting the server mitigates the worst case — the operator can't read ciphertext — but that's a mitigation, not a solution. A proper solution might involve attested key publication (agents bind their cross-signing keys to a TEE attestation), trust-on-first-use with hardware attestation, or a web-of-trust layer where humans vouch for their agents' keys and trust propagates transitively.
+
+**Encrypted key recovery for agent accounts.** Humans use passphrase-protected key backups or cross-signing recovery. Agents need something different — probably TEE-sealed keys where decryption keys never leave the enclave. If an agent restarts or gets redeployed, how does it recover its Megolm sessions without a human typing a passphrase? Nobody has solved this well.
+
+**Agent attestation and identity binding.** An agent's Matrix account is just another account right now. There's no cryptographic link between "this agent belongs to Alice" or "this agent is running on Phala CVM X." Building an attestation layer where agents prove their execution environment and link back to their owner would make agent-to-agent trust tractable.
+
+**Custom Element fork or agent-native client.** Element's UX assumes human-driven flows — interactive verification, timeline scrolling, notification bells. An agent-native client would need different primitives: programmatic key management, bulk verification, structured event streams instead of timelines. Even a thin fork that strips Element down to what agents and power users actually need would be a real contribution.
+
+**Notification routing as a composable primitive.** Agents should be able to subscribe to specific event patterns (new message from human X, agent Y posted a result, room Z had a state change) without drowning in noise. Element's notification model is built for humans reading a timeline. Agents need something closer to a filtered event stream with structured delivery.
+
+**Encrypted bridging.** Everyone still has Telegram and Discord open. A bridge that shuttles messages between platforms without breaking the E2EE trust chain would be a real contribution. Existing bridges (mautrix, matterbridge) either skip encryption or decrypt-and-re-encrypt, which defeats the purpose. Preserving end-to-end integrity across protocols is a research-level problem.
+
+### Under the Hood
+
+The entire server is open source and deployed from GitHub:
+
+- **Source code:** [github.com/teleport-computer/shape-rotator-matrix](https://github.com/teleport-computer/shape-rotator-matrix)
+- **Homeserver:** Continuwuity running inside a Phala Cloud dstack TEE
+- **Deployment:** Push a `v*` tag to the repo — GitHub Actions handles the TEE deploy and health checks automatically
+
+If you want to understand how the knock-approver works, how the lobby flow is structured, or how the signup proxy creates accounts, it's all in the repo. PRs welcome.
+
+There's also a **#matrix-devops** channel in the space for operational discussion — debugging, deploy issues, feature requests for the server infrastructure. Ask in General if you want to be added to it.
+
+### Who Runs This
+
+For now, Andrew Miller is responsible for the server infrastructure, the onboarding flow, and day-to-day administration. Message him directly (`@socrates1024:matrix.org`) if you hit problems, need a join code, or find something broken.
+
+If you're interested in taking over administration or helping with any aspect of it — the homeserver, the lobby flow, the knock code system, the bot infrastructure — he's happy to delegate. The more people who understand how this works, the more resilient it gets.
+
+### Getting Started
+
+1. Get a join code from an organizer
+2. Point your browser to `https://mtrx.shaperotator.xyz/join?code=YOUR_CODE` (or `/signup?code=YOUR_CODE` for a new account on our homeserver)
+3. Follow the prompts
+4. Enable notifications for Announcements
+5. Say hello in General

--- a/deploy/bootstrap_ci_device.py
+++ b/deploy/bootstrap_ci_device.py
@@ -1,0 +1,141 @@
+"""Mint a new device "ci-deploy" under @shape-rotator-2 for GH Actions.
+
+Runs inside dstack-knock-approver-1 where the password + master keys live.
+Logs in with device_id="ci-deploy", uploads device + one-time keys via
+mautrix OlmMachine (sqlite-backed), self-signs the new device with the
+existing SSK from cross_signing.json so it inherits master trust, then
+tars (sqlite store + meta) and prints base64 of the bundle to stdout.
+
+Stash output as GH secret CI_DEPLOY_BOT_BUNDLE_B64.
+"""
+import asyncio, base64, io, json, os, sys, tarfile, tempfile
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+import aiohttp
+
+
+def _canon(obj) -> bytes:
+    """Matrix canonical JSON: sorted keys, no whitespace, UTF-8."""
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True,
+                      ensure_ascii=False).encode("utf-8")
+
+from mautrix.api import HTTPAPI
+from mautrix.client import Client
+from mautrix.client.state_store import MemoryStateStore
+from mautrix.crypto import OlmMachine
+from mautrix.crypto.store.asyncpg import PgCryptoStore
+from mautrix.util.async_db import Database
+from mautrix.types import UserID, TrustState
+
+HS = os.environ.get("HOMESERVER", "https://mtrx.shaperotator.xyz")
+MXID = "@shape-rotator-2:mtrx.shaperotator.xyz"
+DEVICE_ID = "ci-deploy"
+PASSWORD_PATH = Path("/data/shape_rotator_2_password")
+CROSS_SIGNING_PATH = Path("/data/shape_rotator_2_cross_signing.json")
+
+
+def _b64(b): return base64.b64encode(b).decode().rstrip("=")
+
+
+def _sign_object(obj, signer_priv: bytes, user_id: str, key_id: str) -> dict:
+    """Matrix canonical-json signing. Strips signatures/unsigned, attaches sig
+    under signatures[user_id][ed25519:key_id]."""
+    signer = ed25519.Ed25519PrivateKey.from_private_bytes(signer_priv)
+    to_sign = {k: v for k, v in obj.items() if k not in ("signatures", "unsigned")}
+    sig = _b64(signer.sign(_canon(to_sign)))
+    sigs = dict(obj.get("signatures", {}))
+    user_sigs = dict(sigs.get(user_id, {}))
+    user_sigs[f"ed25519:{key_id}"] = sig
+    sigs[user_id] = user_sigs
+    obj["signatures"] = sigs
+    return obj
+
+
+async def main():
+    workdir = Path(tempfile.mkdtemp(prefix="ci-bootstrap-"))
+    crypto_db = workdir / "ci-store.db"
+
+    pw = PASSWORD_PATH.read_text().strip()
+    cs_json = json.loads(CROSS_SIGNING_PATH.read_text())
+    ssk_priv = base64.b64decode(cs_json["self_signing_private"] + "==")
+    ssk_pub = cs_json["ssk_public"]
+
+    # 1. Login as @shape-rotator-2 with explicit device_id="ci-deploy".
+    api = HTTPAPI(base_url=HS)
+    client = Client(mxid=UserID(MXID), base_url=HS, device_id=DEVICE_ID,
+                    state_store=MemoryStateStore())
+    resp = await client.login(password=pw, device_id=DEVICE_ID,
+                              device_name="GH Actions ci-deploy",
+                              store_access_token=True)
+    access_token = resp.access_token
+    print(f"[bootstrap] login ok: device={resp.device_id} token=…{access_token[-6:]}",
+          file=sys.stderr)
+
+    # 2. Init sqlite-backed crypto store + OlmMachine (mirrors approver.py:1486).
+    db = Database.create(f"sqlite:///{crypto_db}",
+                         upgrade_table=PgCryptoStore.upgrade_table)
+    await db.start()
+    cs_store = PgCryptoStore(account_id=MXID,
+                             pickle_key=f"{MXID}:{DEVICE_ID}", db=db)
+    await cs_store.open()
+    olm = OlmMachine(client, cs_store, MemoryStateStore())
+    olm.share_keys_min_trust = TrustState.UNVERIFIED
+    olm.send_keys_min_trust = TrustState.UNVERIFIED
+    await olm.load()
+    client.crypto = olm
+    client.crypto_store = cs_store
+
+    # 3. Upload device keys + one-time keys.
+    await olm.share_keys()
+    print("[bootstrap] device + one-time keys uploaded", file=sys.stderr)
+
+    # 4. Fetch our new device's signed key from the server, sign with SSK,
+    # upload via /keys/signatures/upload. (Borrowed from approver.py:1900.)
+    headers = {"Authorization": f"Bearer {access_token}",
+               "Content-Type": "application/json"}
+    async with aiohttp.ClientSession() as session:
+        device_obj = None
+        for _ in range(8):
+            async with session.post(f"{HS}/_matrix/client/v3/keys/query",
+                                    json={"device_keys": {MXID: [DEVICE_ID]}},
+                                    headers=headers) as r:
+                q = await r.json()
+                device_obj = (q.get("device_keys", {})
+                                .get(MXID, {}).get(DEVICE_ID))
+                if device_obj:
+                    break
+            await asyncio.sleep(1.0)
+        if not device_obj:
+            raise RuntimeError("server never returned our ci-deploy device keys")
+
+        signed = _sign_object(device_obj, ssk_priv, MXID, ssk_pub)
+        async with session.post(f"{HS}/_matrix/client/v3/keys/signatures/upload",
+                                json={MXID: {DEVICE_ID: signed}},
+                                headers=headers) as r:
+            body = await r.json()
+            if r.status != 200 or body.get("failures"):
+                raise RuntimeError(f"signatures/upload {r.status}: {body}")
+    print(f"[bootstrap] cross-signed ci-deploy with SSK={ssk_pub[:8]}…",
+          file=sys.stderr)
+
+    # 5. Close cleanly (flush sqlite).
+    await cs_store.close()
+    await db.stop()
+    await client.api.session.close() if client.api.session else None
+
+    # 6. Bundle = ci-store.db + meta.json, tar.gz, base64 → stdout.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        tar.add(crypto_db, arcname="ci-store.db")
+        meta = json.dumps({"access_token": access_token,
+                           "device_id": DEVICE_ID, "mxid": MXID,
+                           "homeserver": HS,
+                           "pickle_key": f"{MXID}:{DEVICE_ID}"}).encode()
+        info = tarfile.TarInfo("meta.json"); info.size = len(meta)
+        tar.addfile(info, io.BytesIO(meta))
+    sys.stdout.write(base64.b64encode(buf.getvalue()).decode())
+    sys.stdout.flush()
+    print(f"\n[bootstrap] bundle size: {buf.tell()} bytes", file=sys.stderr)
+
+
+asyncio.run(main())

--- a/deploy/send_heads_up.py
+++ b/deploy/send_heads_up.py
@@ -1,0 +1,89 @@
+"""Send the pre-deploy heads-up message into the (E2EE) admin room.
+
+Runs in GH Actions; unpacks CI_DEPLOY_BOT_BUNDLE_B64 (minted by
+bootstrap_ci_device.py), initialises mautrix Client + OlmMachine against
+the bundled sqlite store, sends an encrypted m.room.message via
+send_message_event (mautrix auto-encrypts for E2EE rooms).
+
+Usage:
+  send_heads_up.py <ref> <short_sha> <delay_seconds> <run_id> <commit_msg>
+"""
+import asyncio, base64, io, json, os, sys, tarfile, tempfile
+from pathlib import Path
+
+from mautrix.client import Client
+from mautrix.client.state_store import MemoryStateStore
+from mautrix.crypto import OlmMachine
+from mautrix.crypto.store.asyncpg import PgCryptoStore
+from mautrix.util.async_db import Database
+from mautrix.types import (UserID, EventType, TextMessageEventContent,
+                            MessageType, TrustState, RoomID)
+
+
+class _StateStore(MemoryStateStore):
+    """Wraps MemoryStateStore with find_shared_rooms() — mautrix's OlmMachine
+    needs it during share_group_session to decide which devices to key-share
+    with. We only ever send to one room, so return it for everyone."""
+    def __init__(self, room_id):
+        super().__init__()
+        self._only_room = room_id
+    async def find_shared_rooms(self, user_id):
+        return [self._only_room]
+
+
+async def main():
+    ref, sha, delay, run_id, *rest = sys.argv[1:]
+    commit_msg = rest[0] if rest else ""
+    room_id = os.environ["ADMIN_COMMAND_ROOM"]
+    bundle_b64 = os.environ["CI_DEPLOY_BOT_BUNDLE_B64"]
+
+    tmp = Path(tempfile.mkdtemp(prefix="ci-deploy-"))
+    with tarfile.open(fileobj=io.BytesIO(base64.b64decode(bundle_b64)),
+                      mode="r:gz") as tar:
+        tar.extractall(tmp)
+    meta = json.loads((tmp / "meta.json").read_text())
+
+    # Client wired to the bundled token + device.
+    client = Client(mxid=UserID(meta["mxid"]),
+                    base_url=meta["homeserver"],
+                    token=meta["access_token"],
+                    device_id=meta["device_id"],
+                    state_store=MemoryStateStore())
+
+    # sqlite crypto store from the bundled .db (same setup the bot uses).
+    db = Database.create(f"sqlite:///{tmp / 'ci-store.db'}",
+                         upgrade_table=PgCryptoStore.upgrade_table)
+    await db.start()
+    cs_store = PgCryptoStore(account_id=meta["mxid"],
+                             pickle_key=meta["pickle_key"], db=db)
+    await cs_store.open()
+    olm = OlmMachine(client, cs_store, _StateStore(RoomID(room_id)))
+    olm.share_keys_min_trust = TrustState.UNVERIFIED
+    olm.send_keys_min_trust = TrustState.UNVERIFIED
+    await olm.load()
+    client.crypto = olm
+    client.crypto_store = cs_store
+
+    # Refresh recipient device lists so the megolm session shares with
+    # everyone currently in the room.
+    await client.sync(timeout=3000)
+
+    minutes = max(1, int(delay) // 60)
+    body = (f"🚧 deploying {ref} ({sha}) in ~{minutes} min — "
+            f"mtrx.shaperotator.xyz briefly unreachable while the CVM "
+            f"restarts.\n\n"
+            f"{commit_msg or '(no commit message)'}\n\n"
+            f"to cancel: https://github.com/teleport-computer/"
+            f"shape-rotator-matrix/actions/runs/{run_id}")
+    content = TextMessageEventContent(msgtype=MessageType.TEXT, body=body)
+    evt = await client.send_message_event(RoomID(room_id),
+                                           EventType.ROOM_MESSAGE, content)
+    print(f"[heads-up] sent event_id={evt}", flush=True)
+
+    await cs_store.close()
+    await db.stop()
+    if client.api.session:
+        await client.api.session.close()
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

- ADMIN_COMMAND_ROOM became E2EE around 2026-05-13. The workflow's plaintext `m.room.message` PUT has been silently **soft-failed by continuwuity 0.5.7** since then (200 + event_id returned, but excluded from the room timeline, never reaches `/sync`, no client displays it). Every `🚧 deploying` heads-up for ~2 weeks has been invisible.
- Fix: send via mautrix from a new device `ci-deploy` under `@shape-rotator-2` (same identity the bot uses — Matrix is multi-device, no new mxid). The device self-signs at bootstrap with the existing master cross-signing key, inheriting trust from every verified client.

## Files

- `deploy/bootstrap_ci_device.py` — one-time mint script. Run inside `dstack-knock-approver-1` where `/data/shape_rotator_2_password` and `/data/shape_rotator_2_cross_signing.json` live; emits base64 bundle on stdout, stash as `CI_DEPLOY_BOT_BUNDLE_B64`. Already minted + stashed on this repo.
- `deploy/send_heads_up.py` — ~75 lines. Per-run script. Bundle → tmp → mautrix Client + OlmMachine on bundled sqlite store → `send_message_event` (auto-encrypts).
- `.github/workflows/deploy.yml` — replaces curl PUT with the python script. Adds `apt-get install libolm-dev` + `pip install mautrix python-olm aiosqlite asyncpg`. KNOCK_APPROVER_TOKEN still referenced elsewhere for the CVM .env, just not by this step.

## Test plan

- [x] Bootstrap script runs cleanly inside the approver container; mints `ci-deploy` device, uploads keys, self-signs with SSK, bundle = 7960 b64 chars.
- [x] `send_heads_up.py` invoked from inside the container with the bundle posted a TEST message to `#matrix-devops-2`. Event `$TrlUv4GhUOFPu00_6BZGKdKoeJwTAxZBHB-2YawStNw` lands in `/messages` timeline as `m.room.encrypted` (vs. prior plaintext `$6Fti1hFx5…` which is still absent → soft-failed).
- [x] User confirmed it decrypts and displays in Element.
- [ ] Merging triggers no deploy (workflow only fires on `v*` tag push). Effect lands on the next tag release.

Closes #42. Pairs with #43 (pre-flight cred validation should also `whoami` the bundled token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)