### PR TITLE
Bot-mediated password-free device login (#46)

### DIFF
--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -127,6 +127,22 @@ AUTH = {"Authorization": f"Bearer {TOKEN}"}
 LOBBY_TOKEN = os.environ.get("ONBOARDING_BOT_TOKEN", "").strip() or TOKEN
 LOBBY_AUTH  = {"Authorization": f"Bearer {LOBBY_TOKEN}"}
 
+# --- Bot-mediated device login (issue #46) ---
+# Password-free login for the desktop app: the desktop calls /device-login/start
+# to get a one-time code, the user DMs that code to this bot from their phone,
+# the bot mints an m.login.token for the *verified sender* via the privileged
+# continuwuity endpoint (guarded by MINT_TOKEN_SECRET, shared with the
+# homeserver's mint_login_token_secret), and the desktop polls /device-login/poll
+# to collect it. Feature is off unless MINT_TOKEN_SECRET is set.
+MINT_TOKEN_SECRET = os.environ.get("MINT_TOKEN_SECRET", "").strip()
+DEVICE_LOGIN_TTL  = int(os.environ.get("DEVICE_LOGIN_TTL", "300"))  # seconds
+# Cap auto-joins of fresh DM invites so a flood of invites can't force the bot
+# to join arbitrarily many rooms. N joins per rolling 60s window.
+DEVICE_LOGIN_JOIN_CAP = int(os.environ.get("DEVICE_LOGIN_JOIN_CAP", "10"))
+_AUTOJOIN_TIMES = []
+# code -> {"status": pending|approved|consumed, "sender", "login_token", "expires_at", "room_id"}
+DEVICE_LOGINS = {}
+
 
 async def _login_with_password(username, password, device_id=None):
     """POST /login as username/password. If device_id is given, Matrix returns
@@ -1329,6 +1345,17 @@ async def cmd_help(client, room_id, sender, args):
 COMMANDS["!help"] = cmd_help
 
 
+async def _safe_send(client, room_id, text, label):
+    # An admin-reply send failure (e.g. M_FORBIDDEN in a newly-encrypted
+    # room) must not crash the sync loop — that would also take down the
+    # /join/api web server, which shares the asyncio runtime.
+    try:
+        await _send_msg(client, room_id, text)
+    except Exception as e:
+        print(f"[{label}] send to {room_id} failed: {type(e).__name__}: {e}",
+              flush=True)
+
+
 async def process_admin_command(client, room_id, event_id, sender, body):
     if not OUR_MXID:
         # /whoami failed at startup; refuse to process anything to avoid
@@ -1345,8 +1372,9 @@ async def process_admin_command(client, room_id, event_id, sender, body):
     is_admin = await _is_admin(client, room_id, sender)
     print(f"[admin] dispatch {cmd} from {sender} is_admin={is_admin}", flush=True)
     if not is_admin:
-        await _send_msg(client, room_id,
-            f"{sender}: refused — need PL >= {ADMIN_PL_THRESHOLD} or be on the allowlist")
+        await _safe_send(client, room_id,
+            f"{sender}: refused — need PL >= {ADMIN_PL_THRESHOLD} or be on the allowlist",
+            "admin-refusal")
         audit({"type": "admin_refused", "cmd": cmd, "sender": sender})
         return
     try:
@@ -1355,7 +1383,7 @@ async def process_admin_command(client, room_id, event_id, sender, body):
         result = f"!{cmd[1:]} failed: {type(e).__name__}: {e}"
         print(f"[admin] {cmd} crashed: {e}", flush=True)
     print(f"[admin] sending reply: {result[:120]!r}", flush=True)
-    await _send_msg(client, room_id, result)
+    await _safe_send(client, room_id, result, "admin-reply")
 
 
 async def announce_lobby_events(client):
@@ -1498,16 +1526,17 @@ async def sync_loop():
         try:
             ev_room = str(evt.room_id)
             ev_sender = str(evt.sender)
-            if ev_room != ADMIN_COMMAND_ROOM:
-                return
             if ev_sender == OUR_MXID:
                 return
             body = (getattr(evt.content, "body", "") or "").strip()
-            if not body.startswith("!"):
+            if ev_room == ADMIN_COMMAND_ROOM:
+                if body.startswith("!"):
+                    await admin_queue.put((str(evt.event_id), ev_sender, body))
                 return
-            await admin_queue.put((str(evt.event_id), ev_sender, body))
+            # Any other room: a DM may carry a device-login code (issue #46).
+            await maybe_approve_device_login(ev_sender, body, ev_room)
         except Exception as e:
-            print(f"[admin handler] {type(e).__name__}: {e}", flush=True)
+            print(f"[msg handler] {type(e).__name__}: {e}", flush=True)
 
     client.add_event_handler(_MAU_EventType.ROOM_MESSAGE, on_room_message)
 
@@ -1547,6 +1576,30 @@ async def sync_loop():
                 await asyncio.gather(*tasks, return_exceptions=True)
         except Exception as e:
             print(f"[handle_sync error] {type(e).__name__}: {e}", flush=True)
+
+        # Device-login (issue #46): auto-join fresh DM invites so we can read the
+        # code the user sends. Only direct invites, only when the feature is on.
+        if MINT_TOKEN_SECRET:
+            for inv_room, inv in data.get("rooms", {}).get("invite", {}).items():
+                evs = inv.get("invite_state", {}).get("events", [])
+                is_direct = any(
+                    e.get("type") == "m.room.member"
+                    and e.get("state_key") == OUR_MXID
+                    and (e.get("content") or {}).get("is_direct") is True
+                    for e in evs)
+                if not is_direct:
+                    continue
+                now = time.time()
+                _AUTOJOIN_TIMES[:] = [t for t in _AUTOJOIN_TIMES if now - t < 60]
+                if len(_AUTOJOIN_TIMES) >= DEVICE_LOGIN_JOIN_CAP:
+                    print(f"[device-login] join cap hit, skipping {inv_room}", flush=True)
+                    continue
+                _AUTOJOIN_TIMES.append(now)
+                try:
+                    await client.api.request("POST", f"/_matrix/client/v3/join/{inv_room}")
+                    print(f"[device-login] joined DM {inv_room}", flush=True)
+                except Exception as e:
+                    print(f"[device-login] join {inv_room} failed: {e}", flush=True)
 
         # Cleartext flows — knock events on the space + vetting rooms.
         for room_id, user_id, reason in iter_knock_events(data.get("rooms", {})):
@@ -1602,6 +1655,95 @@ async def _admin_invite(mxid, room_id, reason="signup auto-invite"):
         url = f"{HS}/_matrix/client/v3/rooms/{room_id}/invite"
         async with s.post(url, json={"user_id": mxid, "reason": reason}) as r:
             return r.status, await r.text()
+
+# --- device-login relay (issue #46) ---
+
+async def _mint_login_token(mxid):
+    """Call the privileged continuwuity endpoint to mint an m.login.token for an
+    already-verified local user. Returns (status, login_token | error_text)."""
+    async with aiohttp.ClientSession(headers={
+        "Authorization": f"Bearer {MINT_TOKEN_SECRET}",
+        "Content-Type": "application/json",
+    }) as s:
+        async with s.post(f"{HS}/_conduwuit/mint_login_token",
+                          json={"user_id": mxid}) as r:
+            if r.status == 200:
+                return 200, (await r.json()).get("login_token")
+            return r.status, (await r.text())[:200]
+
+
+async def _leave_room(room_id):
+    """Leave a room as the bot (own MATRIX_TOKEN). Plain state op, no E2EE."""
+    async with aiohttp.ClientSession(headers={**AUTH, "Content-Type": "application/json"}) as s:
+        async with s.post(f"{HS}/_matrix/client/v3/rooms/{room_id}/leave", json={}) as r:
+            return r.status, await r.text()
+
+
+def _prune_device_logins():
+    now = time.time()
+    for code in [c for c, e in DEVICE_LOGINS.items() if e["expires_at"] < now]:
+        del DEVICE_LOGINS[code]
+
+
+async def device_login_start(request):
+    """Desktop asks for a one-time code to show as a QR. Returns the code plus a
+    matrix.to deep link to this bot so the phone can open a DM and send it."""
+    if not MINT_TOKEN_SECRET:
+        return web.json_response({"error": "device_login_disabled"}, status=503)
+    _prune_device_logins()
+    code = "SRDL-" + secrets.token_hex(4).upper()
+    DEVICE_LOGINS[code] = {"status": "pending", "sender": None,
+                           "login_token": None, "expires_at": time.time() + DEVICE_LOGIN_TTL,
+                           "room_id": None}
+    bot = OUR_MXID or ""
+    return web.json_response({
+        "code": code,
+        "bot_mxid": bot,
+        "matrix_to": f"https://matrix.to/#/{bot}",
+        "expires_in": DEVICE_LOGIN_TTL,
+    })
+
+
+async def device_login_poll(request):
+    """Desktop polls with its code; once the phone has approved, returns the
+    login_token exactly once (status flips to consumed)."""
+    code = (request.query.get("code") or "").strip()
+    _prune_device_logins()
+    entry = DEVICE_LOGINS.get(code)
+    if not entry:
+        return web.json_response({"status": "expired"}, status=404)
+    if entry["status"] == "approved":
+        entry["status"] = "consumed"
+        return web.json_response({"status": "approved",
+                                  "login_token": entry["login_token"]})
+    return web.json_response({"status": entry["status"]})
+
+
+async def maybe_approve_device_login(sender, body, room_id):
+    """A DM arrived from `sender`. If its body is a pending device-login code,
+    mint a login token for that verified sender and mark the code approved."""
+    if not MINT_TOKEN_SECRET:
+        return
+    code = body.strip().split()[-1] if body.strip() else ""
+    _prune_device_logins()
+    entry = DEVICE_LOGINS.get(code)
+    if not entry or entry["status"] != "pending":
+        return
+    st, result = await _mint_login_token(sender)
+    if st != 200:
+        audit({"type": "device_login_mint_failed", "sender": sender,
+               "status": st, "body": str(result)})
+        print(f"[device-login] mint for {sender} -> {st}: {result}", flush=True)
+        return
+    entry.update(status="approved", sender=sender, login_token=result, room_id=room_id)
+    audit({"type": "device_login_approved", "sender": sender, "code": code})
+    print(f"[device-login] approved {sender} (code {code})", flush=True)
+    # The DM has served its purpose; leave so we don't accumulate membership.
+    try:
+        await _leave_room(room_id)
+    except Exception as e:
+        print(f"[device-login] leave {room_id} failed: {e}", flush=True)
+
 
 async def _as_user(access_token, method, path, body=None):
     """Make a request as the freshly-registered user."""
@@ -1951,6 +2093,8 @@ async def run_http():
     app.router.add_post("/signup/api",           signup_handler)
     app.router.add_post("/signup/api/crosssign", crosssign_handler)
     app.router.add_post("/join/api",             join_handler)
+    app.router.add_post("/device-login/start",   device_login_start)
+    app.router.add_get("/device-login/poll",     device_login_poll)
     app.router.add_get("/health",                lambda r: web.Response(text="ok"))
     runner = web.AppRunner(app)
     await runner.setup()
@@ -2019,11 +2163,21 @@ async def main():
     merge_seed(SIGNUP_PATH, "INITIAL_SIGNUP_CODES")
 
     await run_http()
-    # Run main sync_loop (knocks, vetting, admin commands) and lobby_sync_loop
-    # (dedicated onboarding-bot identity for the lobby flow) in parallel.
-    # If LOBBY_TOKEN == TOKEN (no dedicated bot configured), both loops sync
-    # the same user — works but wasteful; configure ONBOARDING_BOT_TOKEN.
-    await asyncio.gather(sync_loop(), lobby_sync_loop())
+    # Supervisor: a crash in either loop must NOT take down the asyncio
+    # runtime (which would also kill the /join/api web server started
+    # above). Log the exception, sleep, restart the loop.
+    async def _supervised(name, factory):
+        while True:
+            try:
+                await factory()
+            except Exception as e:
+                print(f"[supervisor] {name} crashed: {type(e).__name__}: {e}; "
+                      f"restarting in 5s", flush=True)
+                await asyncio.sleep(5)
+    await asyncio.gather(
+        _supervised("sync_loop", sync_loop),
+        _supervised("lobby_sync_loop", lobby_sync_loop),
+    )
 
 if __name__ == "__main__":
     try:

--- a/tests/device_login_e2e.py
+++ b/tests/device_login_e2e.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""End-to-end test for bot-mediated device login (issue #46).
+
+Boots the locally-built patched continuwuity, registers a user, then drives the
+approver's actual relay functions: start -> (simulated DM from the user) ->
+mint -> poll -> redeem the m.login.token and confirm whoami. Run after building
+the patched binary in ../continuwuity-fork.
+"""
+import asyncio, json, os, subprocess, sys, tempfile, time, urllib.request, shutil
+from pathlib import Path
+
+PORT = 6178
+BASE = f"http://127.0.0.1:{PORT}"
+SECRET = "testsecret123"
+REG = "testreg"
+FORK = Path(__file__).resolve().parents[3] / "continuwuity-fork"
+BIN = next((p for p in [FORK / "target/debug/conduwuit", FORK / "target/release/conduwuit"]
+            if p.exists()), None)
+
+# approver.py needs these in the env at import time.
+os.environ.update(HS=BASE, MATRIX_TOKEN="", MINT_TOKEN_SECRET=SECRET,
+                  DEVICE_LOGIN_TTL="300", SPACE_ID="!dummy:localhost",
+                  LOG_PATH=tempfile.mktemp(prefix="audit-", suffix=".jsonl"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "knock-approver"))
+
+
+def post(path, body, token=None):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(BASE + path, data=data, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.load(r)
+    except urllib.error.HTTPError as e:
+        body = e.read()
+        try:
+            return e.code, json.loads(body)
+        except Exception:
+            return e.code, None
+
+
+def get(path, token=None):
+    req = urllib.request.Request(BASE + path)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as r:
+        return r.status, json.load(r)
+
+
+async def main():
+    assert BIN, "no built conduwuit binary in ../continuwuity-fork/target"
+    data_dir = tempfile.mkdtemp(prefix="cw-dl-")
+    env = {**os.environ, "CONDUWUIT_SERVER_NAME": "localhost",
+           "CONDUWUIT_DATABASE_BACKEND": "rocksdb", "CONDUWUIT_DATABASE_PATH": data_dir,
+           "CONDUWUIT_ADDRESS": "127.0.0.1", "CONDUWUIT_PORT": str(PORT),
+           "CONDUWUIT_ALLOW_REGISTRATION": "true", "CONDUWUIT_REGISTRATION_TOKEN": REG,
+           "CONDUWUIT_MINT_LOGIN_TOKEN_SECRET": SECRET, "CONDUWUIT_LOG": "warn"}
+    logf = open(os.path.join(data_dir, "log"), "w+")
+    srv = subprocess.Popen([str(BIN)], env=env, stdout=logf, stderr=subprocess.STDOUT)
+    try:
+        for _ in range(60):
+            try:
+                get("/_matrix/client/versions"); break
+            except Exception:
+                if srv.poll() is not None:
+                    raise SystemExit("server died")
+                time.sleep(1)
+
+        # Fresh DB: grab the one-time first-account setup token from the banner.
+        import re
+        reg_token = None
+        for _ in range(20):
+            banner = re.sub(r"\x1b\[[0-9;]*m", "", open(os.path.join(data_dir, "log")).read())
+            m = re.search(r"registration token ([A-Za-z0-9]+)", banner)
+            if m:
+                reg_token = m.group(1); break
+            time.sleep(0.5)
+        assert reg_token, "no first-account token in server log:\n" + banner[-2000:]
+
+        # register @alice
+        _, init = post("/_matrix/client/v3/register", {})
+        _, reg = post("/_matrix/client/v3/register", {
+            "username": "alice", "password": "hunter2hunter2",
+            "auth": {"type": "m.login.registration_token", "token": reg_token,
+                     "session": init["session"]}})
+        alice = reg["user_id"]
+
+        # import the approver's relay logic now that the server is up
+        import approver
+        from aiohttp.test_utils import make_mocked_request
+        approver.OUR_MXID = "@bot:localhost"
+
+        npass = nfail = 0
+        def check(name, ok):
+            nonlocal npass, nfail
+            print(("  ok: " if ok else "  FAIL: ") + name)
+            npass += ok; nfail += (not ok)
+
+        # 1. desktop starts a login -> gets a code
+        resp = await approver.device_login_start(make_mocked_request("POST", "/device-login/start"))
+        code = json.loads(resp.text)["code"]
+        check("start returns a code", code.startswith("SRDL-"))
+        check("code is pending", approver.DEVICE_LOGINS[code]["status"] == "pending")
+
+        # 2. poll before approval -> still pending
+        resp = await approver.device_login_poll(
+            make_mocked_request("GET", f"/device-login/poll?code={code}"))
+        check("poll pending before DM", json.loads(resp.text)["status"] == "pending")
+
+        # 3. the user DMs the code -> bot mints for the verified sender, then
+        #    leaves the DM room (hardening: don't accumulate membership)
+        left = []
+        approver._leave_room = lambda rid: (left.append(rid), asyncio.sleep(0))[1]
+        await approver.maybe_approve_device_login(alice, f"hi {code}", "!dm:localhost")
+        check("approved after DM", approver.DEVICE_LOGINS[code]["status"] == "approved")
+        check("bot leaves DM after approval", left == ["!dm:localhost"])
+        lt = approver.DEVICE_LOGINS[code]["login_token"]
+        check("login_token minted", bool(lt))
+
+        # 4. desktop polls -> gets the token (once)
+        resp = await approver.device_login_poll(
+            make_mocked_request("GET", f"/device-login/poll?code={code}"))
+        polled = json.loads(resp.text)
+        check("poll returns token", polled.get("login_token") == lt)
+        resp2 = await approver.device_login_poll(
+            make_mocked_request("GET", f"/device-login/poll?code={code}"))
+        check("token is one-time (consumed)", json.loads(resp2.text)["status"] == "consumed")
+
+        # 5. redeem the m.login.token -> logged in as alice, no password
+        st, login = post("/_matrix/client/v3/login", {"type": "m.login.token", "token": lt})
+        _, who = get("/_matrix/client/v3/account/whoami", token=login["access_token"])
+        check("redeemed token logs in as alice", who["user_id"] == alice)
+
+        # 6. a stranger's code is ignored
+        await approver.maybe_approve_device_login("@mallory:localhost", "SRDL-DEADBEEF", "!x:localhost")
+        check("unknown code ignored", "SRDL-DEADBEEF" not in approver.DEVICE_LOGINS)
+
+        print(f"----\nPASS={npass} FAIL={nfail}")
+        sys.exit(1 if nfail else 0)
+    finally:
+        srv.terminate()
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+
+asyncio.run(main())


### PR DESCRIPTION
Closes #46.

Password-free Matrix login for the Shape Rotator OS desktop app — no MAS/OAuth2 migration, stays on continuwuity.

## Flow
1. Desktop calls `POST /device-login/start` → one-time `SRDL-` code (shown as QR / matrix.to deep link to the bot).
2. User opens the link on their phone and DMs the code to the approver bot.
3. Bot reads the **homeserver-vouched sender mxid**, mints an `m.login.token` for that user via a privileged continuwuity endpoint, marks the code approved, and leaves the DM.
4. Desktop polls `GET /device-login/poll?code=…` → gets the token **once** → redeems via `m.login.token`.

No password ever touches the desktop, and the user is verified by the homeserver (not by us handling a secret).

## This PR (approver side)
- `/device-login/start` + `/device-login/poll` HTTP endpoints; one-time, short-TTL (`DEVICE_LOGIN_TTL`) codes bound to the verified sender.
- `maybe_approve_device_login()` mints for the DM sender via `POST /_conduwuit/mint_login_token`.
- Auto-join of fresh **direct** invites so the bot can read the DM — **feature-gated on `MINT_TOKEN_SECRET`**.
- Sync loops made crash-isolated (supervisor + `_safe_send`) so a send failure can't take down the shared HTTP server.

### Hardening of the new auto-join surface
- Direct-invite-only.
- Rate cap: `DEVICE_LOGIN_JOIN_CAP` joins / rolling 60s.
- Bot **leaves** the DM room after approval (no membership accumulation).
- **Decision:** no confirmation DM back to the user — the desktop already learns of approval via `/device-login/poll`; replying into an E2EE DM would pull in fragile mautrix megolm key-sharing.

## Server side (separate, not in this repo)
Depends on a small continuwuity patch adding `POST /_conduwuit/mint_login_token` (guarded by `mint_login_token_secret`). That lives on the `mint-login-token` branch of the continuwuity fork; upstream is a Forgejo instance, so it ships to prod as a custom image rather than an upstream PR right now.

## Testing
- `tests/device_login_e2e.py` — **10/10** against a real patched continuwuity binary: start → DM → mint → poll → **redeem as the user (no password)** → one-time → unknown-code-ignored → leave-after-approval.
- continuwuity endpoint: **6/6** (`test_mint_login_token.sh` in the fork) — mint → redeem → whoami + bad/missing-secret, nonexistent-user, remote-user negatives.

### Known untested seam (why this is **draft**)
The e2e calls `maybe_approve_device_login()` directly — it does **not** exercise the real mautrix sync loop, **E2EE decryption of the DM**, `on_room_message` dispatch, or a real **invite auto-join**. The rate-cap/auto-join code has no test coverage. A **live phone/Element X DM test** is required before merge/deploy.

## Not merging yet
Holding until the live phone test passes and the custom continuwuity image is built + deployed (planned for a low-traffic window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
