### PR TITLE
bridge: add tg.py send/tail CLI for the test group (#50)

### DIFF
--- a/bridge/tg.py
+++ b/bridge/tg.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Telegram send/tail CLI for the Matrix<->Telegram relay (issue #50).
+
+Talks to exactly ONE Telegram chat: the test group whose id lives in
+`telegram_chat_id` of the test-fixtures file. That is the single source of
+truth for the destination — this tool will never send anywhere else.
+
+Credentials & session (provisioned on the relay host, never committed/copied):
+  - Telethon user session: $TELEGRAM_SESSION (default ~/.teleport-travel/shapeos_zed)
+  - API id/hash:           $TELEPORT_DIR/.env (TELEGRAM_API_ID / TELEGRAM_API_HASH)
+  - Destination chat id:   $TEST_FIXTURES_PATH (default ~/.teleport-travel/test-fixtures.json)
+
+Single-host rule: a Telethon session used from a second IP is permanently
+invalidated. This script reuses the session in place; it never copies one and
+never performs an interactive re-login. If the session is not authorized, that
+is an operator action — the script fails loudly instead of prompting.
+
+Requires: telethon, python-dotenv (provided in ~/.teleport-travel/venv).
+
+Usage:
+  tg.py send <text>       send <text> to the test group, print the new msg id
+  tg.py tail [n]          print the last n messages (newest last): id, sender, text
+"""
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from telethon import TelegramClient
+from telethon.errors import AuthKeyError
+
+# Provisioned locations; overridable via env so production pairing is an
+# operator config change, never a code change.
+TELEPORT_DIR = Path(os.environ.get("TELEPORT_DIR", Path.home() / ".teleport-travel"))
+SESSION_PATH = os.environ.get("TELEGRAM_SESSION", str(TELEPORT_DIR / "shapeos_zed"))
+ENV_PATH = Path(os.environ.get("TELEGRAM_ENV_PATH", TELEPORT_DIR / ".env"))
+FIXTURES_PATH = Path(os.environ.get("TEST_FIXTURES_PATH", TELEPORT_DIR / "test-fixtures.json"))
+
+
+def load_chat_id() -> int:
+    """Destination chat id comes ONLY from the test-fixtures file."""
+    try:
+        fixtures = json.loads(FIXTURES_PATH.read_text())
+    except FileNotFoundError:
+        raise SystemExit(f"test-fixtures not found: {FIXTURES_PATH}")
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"test-fixtures {FIXTURES_PATH} is not valid JSON: {e}")
+    try:
+        return int(fixtures["telegram_chat_id"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise SystemExit(f"test-fixtures {FIXTURES_PATH} missing/invalid telegram_chat_id: {e}")
+
+
+def make_client() -> TelegramClient:
+    """Build a TelegramClient from the provisioned .env + session path."""
+    load_dotenv(ENV_PATH)  # does not override vars already in the environment
+    api_id = os.environ.get("TELEGRAM_API_ID")
+    api_hash = os.environ.get("TELEGRAM_API_HASH")
+    if not api_id or not api_hash:
+        raise SystemExit(f"TELEGRAM_API_ID/TELEGRAM_API_HASH missing in {ENV_PATH}")
+    try:
+        api_id_int = int(api_id)
+    except ValueError:
+        raise SystemExit(f"TELEGRAM_API_ID in {ENV_PATH} is not an integer: {api_id!r}")
+    return TelegramClient(SESSION_PATH, api_id_int, api_hash)
+
+
+async def _run(action):
+    """Connect with the provisioned session and run `action(client, chat_id)`.
+
+    Uses connect()+is_user_authorized() rather than start(): an unauthorized
+    session means the operator must re-login in place (single-host rule), which
+    we never do from a CLI. Fail loudly instead of hanging on a prompt.
+    """
+    chat_id = load_chat_id()
+    client = make_client()
+    try:
+        await client.connect()
+        try:
+            authorized = await client.is_user_authorized()
+        except AuthKeyError as e:
+            raise SystemExit(f"session auth key unusable ({e}); re-login is an operator action")
+        if not authorized:
+            raise SystemExit(
+                f"session {SESSION_PATH}.session is not authorized; "
+                "re-login in place on the relay host (single-host rule)"
+            )
+        return await action(client, chat_id)
+    finally:
+        await client.disconnect()
+
+
+def _sender_name(sender, sender_id) -> str:
+    # Falls back through readable name -> numeric id -> "unknown" for the
+    # senderless service messages Telegram emits (group creation, pinning, ...).
+    if sender is not None:
+        name = getattr(sender, "first_name", None) or getattr(sender, "title", None)
+        if name:
+            return name
+    if sender_id is not None:
+        return f"id:{sender_id}"
+    return "unknown"
+
+
+async def send(text: str) -> None:
+    async def _do(client, chat_id):
+        msg = await client.send_message(chat_id, text)
+        print(f"sent id={msg.id} chat={chat_id}")
+    await _run(_do)
+
+
+async def tail(n: int) -> None:
+    async def _do(client, chat_id):
+        # iter_messages yields newest-first; reverse so the window reads as a
+        # transcript (oldest -> newest), matching `tail` semantics.
+        messages = []
+        async for msg in client.iter_messages(chat_id, limit=n):
+            messages.append(msg)
+        for msg in reversed(messages):
+            sender = await msg.get_sender()
+            name = _sender_name(sender, msg.sender_id)
+            when = msg.date.isoformat(timespec="seconds") if msg.date else "-"
+            body = msg.text or "(non-text message)"
+            print(f"[{when}] id={msg.id} from={name}: {body}")
+    await _run(_do)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tg.py",
+        description="Send to / tail the one Telegram test group for the relay.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_send = sub.add_parser("send", help="send <text> to the test group")
+    p_send.add_argument("text", help="message text to send")
+
+    p_tail = sub.add_parser("tail", help="print the last n messages (id, sender, text)")
+    p_tail.add_argument("n", type=int, nargs="?", default=10, help="number of messages (default 10)")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "send":
+        asyncio.run(send(args.text))
+    else:
+        asyncio.run(tail(args.n))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Telegram side of the Matrix<->Telegram relay (parent #49). Adds `bridge/tg.py`, a Telethon CLI scoped to **one** chat — the test group whose `telegram_chat_id` comes solely from `~/.teleport-travel/test-fixtures.json`.

- `tg.py send <text>` — send to the test group, prints the new message id.
- `tg.py tail [n]` — prints the last n messages (`id`, `sender`, `text`), newest last (default n=10).

Credentials/session handling:
- Reuses the provisioned Telethon session in place (single-host rule: never copied, never used from a second IP).
- API id/hash from the provisioned `.env` via `python-dotenv`.
- Uses `connect()` + `is_user_authorized()` rather than `start()`: an unauthorized session is an operator re-login action (single-host rule), so the CLI fails loudly instead of hanging on an interactive prompt.
- Destination is read from `test-fixtures.json` only; this tool will never send anywhere else.
- All paths (`TELEGRAM_SESSION`, `TELEPORT_DIR`, `TEST_FIXTURES_PATH`) are env-overridable so production pairing is an operator config change, not a code edit.

## Risk
Low. New file only; no changes to existing Matrix/approver/landing code or the homeserver deploy. Sends exclusively to the allowlisted test group. No secrets, sessions, or `.env` committed (`.gitignore` already covers `.env`; session lives outside the repo).

## Verification
Live round-trip against the test group, using `~/.teleport-travel/venv/bin/python` and the provisioned session/fixtures (captured under `~/paseo-batch/out/50/`):

`tg.py tail 5` (read-only warm-up) → confirmed the group is reachable.
`tg.py send "<marker>"`:
```
sent id=2 chat=-1004408364867
```
`tg.py tail 5` (read-back):
```
[2026-07-04T19:12:09+00:00] id=1 from=unknown: (non-text message)
[2026-07-04T20:03:25+00:00] id=2 from=Teleport: relay-verify-50-1783195404  (shape-rotator-matrix bridge/tg.py live verification, issue #50)
```
Marker `relay-verify-50-1783195404` round-tripped: sent → read back with sender "Teleport" and the exact body. `python3 -m py_compile bridge/tg.py` clean; CLI `--help` for both subcommands verified.

`bridge/acceptance.sh` does not exist yet (it lands with the Matrix side of the relay); this live send+tail round-trip is the strongest check this side allows.