### PR TITLE
approver: complete admin command surface (#7)

### DIFF
--- a/.evidence/issue-7/drive_admin_moderation.py
+++ b/.evidence/issue-7/drive_admin_moderation.py
@@ -1,0 +1,235 @@
+"""Evidence driver for PR #68 / issue #7 — the four NEW admin moderation commands.
+
+`!kick` / `!ban` / `!unban` / `!stats` do not exist in tests/admin_e2ee.py (that
+gate covers `!mint` only). This driver exercises them end-to-end against the
+live dev-stack homeserver exactly the way a human admin would, over the same
+E2EE path the standing gate uses:
+
+  * a real mautrix-python client with OlmMachine + PgCryptoStore per user,
+  * commands sent ENCRYPTED into the encrypted admin command room,
+  * the branch's own knock-approver/approver.py (bind-mounted into the stack,
+    running in the knock-approver container) decrypts, PL-gates, executes the
+    membership calls against the real homeserver, and replies encrypted,
+  * this driver decrypts the bot's replies and asserts them, AND verifies the
+    victim's membership state independently over the client-server HTTP API.
+
+Run inside the test-runner of a standing e2e stack (see flow.md for the exact
+compose dance). Env (same names run_in_runner.sh exports for admin_e2ee.py):
+  DEV_HS, DEV_REG_TOKEN, ADMIN_COMMAND_ROOM, ADMIN_TOKEN, ADMIN_MXID, SPACE_ID
+"""
+import asyncio, json, os, secrets, sys, time
+import urllib.parse, urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "tests"))
+
+from sas_e2e import make_client, sync_once, register  # noqa: E402
+
+from mautrix.types import (EventType, MessageType, TextMessageEventContent)  # noqa: E402
+
+HS = os.environ.get("DEV_HS", "http://landing:80").rstrip("/")
+REG_TOKEN = os.environ["DEV_REG_TOKEN"]
+ADMIN_ROOM = os.environ["ADMIN_COMMAND_ROOM"]
+ADMIN_TOKEN = os.environ["ADMIN_TOKEN"]
+BOT_MXID = os.environ["ADMIN_MXID"]          # in the test stack the bootstrap admin IS the bot
+SPACE_ID = os.environ["SPACE_ID"]
+
+results = []
+class StepFailed(Exception):
+    """Raised by log() on the first FAIL so cleanup always runs."""
+
+def summarize():
+    failed = [n for n, ok in results if not ok]
+    print(f"\n=== {len(results) - len(failed)}/{len(results)} pass ===", flush=True)
+    if failed:
+        print("FAILED: " + ", ".join(failed), file=sys.stderr)
+
+def log(name, ok, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {name}" + (f"  ({detail})" if detail else ""), flush=True)
+    results.append((name, ok))
+    if not ok:
+        print("[driver] FAILING — remaining steps skipped", flush=True)
+        raise StepFailed(name)
+
+def api(method, path, token, body=None):
+    """Raw client-server HTTP call; returns (status, parsed_json)."""
+    data = json.dumps(body).encode() if body is not None else b"{}"
+    req = urllib.request.Request(
+        f"{HS}{path}", data=data, method=method,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode() or "{}")
+
+def room_path(room):
+    return "/_matrix/client/v3/rooms/" + urllib.parse.quote(room, safe="")
+
+def membership_of(user, room=SPACE_ID):
+    s, r = api("GET", f"{room_path(room)}/state/m.room.member/{urllib.parse.quote(user, safe='')}", ADMIN_TOKEN)
+    return r.get("membership")
+
+async def invite_and_join(user_token, user_mxid, room):
+    """Invite via the PL-100 admin token, then join with the user's own token."""
+    s, _ = api("POST", f"{room_path(room)}/invite", ADMIN_TOKEN, {"user_id": user_mxid})
+    assert s == 200, f"invite {user_mxid} -> {room}: HTTP {s}"
+    s, _ = api("POST", f"{room_path(room)}/join", user_token)
+    assert s == 200, f"join {user_mxid} -> {room}: HTTP {s}"
+
+class CmdClient:
+    """One E2EE-capable admin-command sender (mautrix client + reply capture)."""
+    def __init__(self, client, crypto_store, state_store, db, mxid):
+        self.client, self.cs, self.ss, self.db, self.mxid = client, crypto_store, state_store, db, mxid
+        self.inbox = []           # (sender, body) of every decrypted non-own message
+        client.add_event_handler(EventType.ROOM_MESSAGE, self._on_msg)
+
+    async def _on_msg(self, evt):
+        body = (getattr(evt.content, "body", "") or "")
+        if str(evt.room_id) == ADMIN_ROOM and str(evt.sender) != self.mxid:
+            self.inbox.append((str(evt.sender), body))
+            print(f"[driver] {self.mxid} received from {evt.sender}: {body[:110]!r}", flush=True)
+
+    async def send_cmd(self, cmd):
+        eid = await self.client.send_message_event(
+            ADMIN_ROOM, EventType.ROOM_MESSAGE,
+            TextMessageEventContent(msgtype=MessageType.TEXT, body=cmd))
+        print(f"[driver] {self.mxid} sent (encrypted) {cmd!r} as {eid}", flush=True)
+        return eid
+
+    async def wait_reply(self, needle, deadline_s=90):
+        """Sync until the bot's decrypted reply contains `needle`; return it."""
+        deadline = time.time() + deadline_s
+        while time.time() < deadline:
+            await sync_once(self.client, self.ss, timeout=2000)
+            for sender, body in self.inbox:
+                if sender == BOT_MXID and needle in body:
+                    return body
+        return None
+
+
+async def spawn_e2ee_user(prefix):
+    username = f"{prefix}_{int(time.time())}_{secrets.token_hex(2)}"
+    device = f"DRV{secrets.token_hex(2)}"
+    user_mxid, user_token = register(username, secrets.token_urlsafe(32), device)
+    print(f"[driver] e2ee user: {user_mxid} device={device}", flush=True)
+    client, cs, ss, db = await make_client(
+        user_mxid, user_token, device, db_path=f"/tmp/drv_{secrets.token_hex(4)}.db")
+    await client.crypto.share_keys()
+    cc = CmdClient(client, cs, ss, db, user_mxid)
+    E2EE_USERS.append(cc)
+    return cc, user_mxid, user_token
+
+
+E2EE_USERS = []   # every spawned CmdClient, for guaranteed db teardown
+
+async def main():
+    try:
+        await run_steps()
+    except StepFailed:
+        pass
+    finally:
+        for u in E2EE_USERS:
+            try:
+                await u.db.stop()
+            except Exception:
+                pass
+    summarize()
+    if any(not ok for _, ok in results):
+        sys.exit(1)
+
+async def run_steps():
+    # --- user A: PL-50 admin in the command room (same setup as admin_e2ee.py)
+    A, a_mxid, _ = await spawn_e2ee_user("mod_admin")
+    s, pl = api("GET", f"{room_path(ADMIN_ROOM)}/state/m.room.power_levels", ADMIN_TOKEN)
+    assert s == 200, f"read power_levels: HTTP {s}"
+    pl.setdefault("users", {})[a_mxid] = 50
+    s, _ = api("PUT", f"{room_path(ADMIN_ROOM)}/state/m.room.power_levels", ADMIN_TOKEN, pl)
+    log("A bumped to PL 50 in admin command room", s == 200, f"status={s}")
+    # invite+join via raw HTTP (A.client token lives in the HTTPAPI object)
+    a_token = A.client.api.token
+    await invite_and_join(a_token, a_mxid, ADMIN_ROOM)
+    # --- user N: joins the command room but keeps PL 0 (the PL-gate negative)
+    N, n_mxid, n_token = await spawn_e2ee_user("mod_pleb")
+    await invite_and_join(n_token, n_mxid, ADMIN_ROOM)
+    # --- user V: plain victim, no client needed (raw HTTP only)
+    v_name = f"mod_victim_{int(time.time())}_{secrets.token_hex(2)}"
+    v_mxid, v_token = register(v_name, secrets.token_urlsafe(32), f"DTV{secrets.token_hex(2)}")
+    print(f"[driver] victim user: {v_mxid}", flush=True)
+
+    for _ in range(6):   # warmup syncs: learn room state, exchange device keys
+        await sync_once(A.client, A.ss, timeout=2000, first=True)
+    for _ in range(6):
+        await sync_once(N.client, N.ss, timeout=2000, first=True)
+    log("admin command room is E2EE for A", await A.ss.is_encrypted(ADMIN_ROOM))
+
+    # 0. A (PL 50) asks !stats first. This is not just a feature check: N's
+    # client must have DECRYPTED real bot traffic in this room before it
+    # sends, or N's megolm session gets keyed to a device set that omits the
+    # bot and the bot can never decrypt N's command ("no session with given
+    # ID" — seen live on the first attempt). Seeing the bot speak first is
+    # also exactly what a real admin room looks like.
+    await A.send_cmd("!stats")
+    body = await A.wait_reply("last 24h:")
+    ok = body is not None and "top captcha keywords:" in body and "pending=0" in body
+    log("!stats (A) returns report (knocks/promoted/rejected/pending + keywords)", ok, f"reply={body!r}")
+    # N must decrypt the bot's reply too — proves N↔bot device discovery BOTH
+    # ways before N sends anything the gate needs to read.
+    deadline = time.time() + 60
+    while time.time() < deadline and not any(s == BOT_MXID for s, _ in N.inbox):
+        await sync_once(N.client, N.ss, timeout=2000)
+    log("N decrypted live bot traffic in the room (pre-send device discovery)",
+        any(s == BOT_MXID for s, _ in N.inbox),
+        f"inbox={[(s, b[:40]) for s, b in N.inbox]!r}")
+
+    # 1. PL gate: N (PL 0) is refused.
+    await N.send_cmd("!stats")
+    body = await N.wait_reply("refused — need PL >= 50")
+    log("PL gate: non-admin refused", body is not None,
+        f"reply={body!r}; inbox={[(s, b[:40]) for s, b in N.inbox]!r}")
+
+    # 2. usage guard: !kick with no target.
+    await A.send_cmd("!kick")
+    body = await A.wait_reply("usage: !kick")
+    log("usage guard: bare !kick answered with usage", body is not None, f"reply={body!r}")
+
+    # 3. self-guard: the bot refuses to kick itself.
+    await A.send_cmd(f"!kick {BOT_MXID}")
+    body = await A.wait_reply("refused: I will not kick myself")
+    log("self-guard: bot refuses !kick of itself", body is not None, f"reply={body!r}")
+
+    # 4. (moved up: A's !stats ran as step 0 above)
+
+    # 5. !kick — invite V into the space, V joins, admin kicks them out.
+    await invite_and_join(v_token, v_mxid, SPACE_ID)
+    log("victim joined the space (pre-state)", membership_of(v_mxid) == "join",
+        f"membership={membership_of(v_mxid)}")
+    await A.send_cmd(f"!kick {v_mxid} evidence-driver kick test")
+    body = await A.wait_reply(f"kicked {v_mxid} from the space")
+    log("!kick removes a member (bot reply)", body is not None, f"reply={body!r}")
+    m = membership_of(v_mxid)
+    log("!kick verified over client-server API", m == "leave", f"membership={m}")
+
+    # 6. !ban — ban the (now-kicked) user.
+    await A.send_cmd(f"!ban {v_mxid} evidence-driver ban test")
+    body = await A.wait_reply(f"banned {v_mxid} from the space")
+    log("!ban bans the user (bot reply)", body is not None, f"reply={body!r}")
+    m = membership_of(v_mxid)
+    log("!ban verified over client-server API", m == "ban", f"membership={m}")
+
+    # 7. !unban — lift the ban.
+    await A.send_cmd(f"!unban {v_mxid} evidence-driver unban test")
+    body = await A.wait_reply(f"unbanned {v_mxid} from the space")
+    log("!unban lifts the ban (bot reply)", body is not None, f"reply={body!r}")
+    m = membership_of(v_mxid)
+    log("!unban verified over client-server API", m == "leave", f"membership={m}")
+
+    # 8. !stats still parses after the moderation traffic.
+    await A.send_cmd("!stats")
+    body = await A.wait_reply("last 24h:")
+    log("!stats still well-formed after moderation traffic", body is not None, f"reply={body!r}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.evidence/issue-7/e2e_gate_transcript.txt
+++ b/.evidence/issue-7/e2e_gate_transcript.txt
@@ -1,0 +1,615 @@
+[run_e2e] compose project: shape-rotator-e2e-751775899
+[run_e2e] starting continuwuity
+time="2026-08-16T13:56:47-05:00" level=warning msg="The \"CONDUWUIT_BOOTSTRAP_TOKEN\" variable is not set. Defaulting to a blank string."
+ Network shape-rotator-e2e-751775899_default  Creating
+ Network shape-rotator-e2e-751775899_default  Created
+ Volume "shape-rotator-e2e-751775899_knock-test-data"  Creating
+ Volume "shape-rotator-e2e-751775899_knock-test-data"  Created
+ Volume "shape-rotator-e2e-751775899_shared"  Creating
+ Volume "shape-rotator-e2e-751775899_shared"  Created
+ Volume "shape-rotator-e2e-751775899_continuwuity-test-data"  Creating
+ Volume "shape-rotator-e2e-751775899_continuwuity-test-data"  Created
+ Container shape-rotator-e2e-751775899-continuwuity-1  Creating
+ Container shape-rotator-e2e-751775899-continuwuity-1  Created
+ Container shape-rotator-e2e-751775899-continuwuity-1  Starting
+ Container shape-rotator-e2e-751775899-continuwuity-1  Started
+[run_e2e] waiting for bootstrap token to appear in continuwuity logs
+[run_e2e] bootstrap token: hL4VaCsee0uSugVS
+[run_e2e] building all images
+#0 building with "default" instance using docker driver
+
+#1 [bootstrap internal] load build definition from Dockerfile
+#1 transferring dockerfile: 693B done
+#1 DONE 0.0s
+
+#2 [bootstrap internal] load metadata for docker.io/library/python:3.11-slim
+#2 DONE 0.0s
+
+#3 [bootstrap internal] load .dockerignore
+#3 transferring context: 2B done
+#3 DONE 0.0s
+
+#4 [bootstrap 1/4] FROM docker.io/library/python:3.11-slim
+#4 DONE 0.0s
+
+#5 [bootstrap 2/4] RUN apt-get update && apt-get install -y --no-install-recommends         libolm3 libolm-dev gcc curl ca-certificates  && rm -rf /var/lib/apt/lists/*
+#5 CACHED
+
+#6 [bootstrap 3/4] RUN pip install --no-cache-dir         aiohttp         cryptography         'mautrix[e2be]'         asyncpg         aiosqlite         'matrix-nio[e2e]'         unpaddedbase64         base58         pyaes         python-olm
+#6 CACHED
+
+#7 [bootstrap 4/4] WORKDIR /repo
+#7 CACHED
+
+#8 [bootstrap] exporting to image
+#8 exporting layers done
+#8 writing image sha256:4db11899cae78c19a7ef6f1bc8dbcc430cc7d85deb1aa88b2d08f8735412ab67 done
+#8 naming to docker.io/library/shape-rotator-e2e-751775899-bootstrap done
+#8 DONE 0.0s
+
+#9 [knock-approver internal] load build definition from Dockerfile
+#9 transferring dockerfile: 693B done
+#9 DONE 0.0s
+
+#2 [knock-approver internal] load metadata for docker.io/library/python:3.11-slim
+#2 DONE 0.0s
+
+#10 [knock-approver internal] load .dockerignore
+#10 transferring context: 2B done
+#10 DONE 0.0s
+
+#4 [knock-approver 1/4] FROM docker.io/library/python:3.11-slim
+#4 DONE 0.0s
+
+#5 [knock-approver 2/4] RUN apt-get update && apt-get install -y --no-install-recommends         libolm3 libolm-dev gcc curl ca-certificates  && rm -rf /var/lib/apt/lists/*
+#5 CACHED
+
+#6 [knock-approver 3/4] RUN pip install --no-cache-dir         aiohttp         cryptography         'mautrix[e2be]'         asyncpg         aiosqlite         'matrix-nio[e2e]'         unpaddedbase64         base58         pyaes         python-olm
+#6 CACHED
+
+#7 [knock-approver 4/4] WORKDIR /repo
+#7 CACHED
+
+#11 [knock-approver] exporting to image
+#11 exporting layers done
+#11 writing image sha256:bf5689fe0b1824487ebddf8741fb3d558aae081fbb65278d933adba425bc9833 done
+#11 naming to docker.io/library/shape-rotator-e2e-751775899-knock-approver done
+#11 DONE 0.0s
+
+#12 [test-runner internal] load build definition from Dockerfile
+#12 transferring dockerfile: 693B done
+#12 DONE 0.0s
+
+#2 [test-runner internal] load metadata for docker.io/library/python:3.11-slim
+#2 DONE 0.0s
+
+#13 [test-runner internal] load .dockerignore
+#13 transferring context: 2B done
+#13 DONE 0.0s
+
+#4 [test-runner 1/4] FROM docker.io/library/python:3.11-slim
+#4 DONE 0.0s
+
+#5 [test-runner 2/4] RUN apt-get update && apt-get install -y --no-install-recommends         libolm3 libolm-dev gcc curl ca-certificates  && rm -rf /var/lib/apt/lists/*
+#5 CACHED
+
+#6 [test-runner 3/4] RUN pip install --no-cache-dir         aiohttp         cryptography         'mautrix[e2be]'         asyncpg         aiosqlite         'matrix-nio[e2e]'         unpaddedbase64         base58         pyaes         python-olm
+#6 CACHED
+
+#7 [test-runner 4/4] WORKDIR /repo
+#7 CACHED
+
+#14 [test-runner] exporting to image
+#14 exporting layers done
+#14 writing image sha256:ca88501e2275b281e2c97d249d4cceea8613770dc32bb8d847ff0ef7dcc42c34 done
+#14 naming to docker.io/library/shape-rotator-e2e-751775899-test-runner done
+#14 DONE 0.0s
+[run_e2e] bringing up bootstrap + approver + landing
+ Container shape-rotator-e2e-751775899-continuwuity-1  Running
+ Container shape-rotator-e2e-751775899-bootstrap-1  Creating
+ Container shape-rotator-e2e-751775899-bootstrap-1  Created
+ Container shape-rotator-e2e-751775899-knock-approver-1  Creating
+ Container shape-rotator-e2e-751775899-knock-approver-1  Created
+ Container shape-rotator-e2e-751775899-landing-1  Creating
+ Container shape-rotator-e2e-751775899-landing-1  Created
+ Container shape-rotator-e2e-751775899-bootstrap-1  Starting
+ Container shape-rotator-e2e-751775899-bootstrap-1  Started
+ Container shape-rotator-e2e-751775899-bootstrap-1  Waiting
+ Container shape-rotator-e2e-751775899-bootstrap-1  Exited
+ Container shape-rotator-e2e-751775899-knock-approver-1  Starting
+ Container shape-rotator-e2e-751775899-knock-approver-1  Started
+ Container shape-rotator-e2e-751775899-landing-1  Starting
+ Container shape-rotator-e2e-751775899-landing-1  Started
+[run_e2e] running test-runner
+ Container shape-rotator-e2e-751775899-continuwuity-1  Running
+ Container shape-rotator-e2e-751775899-bootstrap-1  Created
+ Container shape-rotator-e2e-751775899-knock-approver-1  Running
+ Container shape-rotator-e2e-751775899-landing-1  Running
+ Container shape-rotator-e2e-751775899-bootstrap-1  Starting
+ Container shape-rotator-e2e-751775899-bootstrap-1  Started
+ Container shape-rotator-e2e-751775899-bootstrap-1  Waiting
+ Container shape-rotator-e2e-751775899-bootstrap-1  Exited
+[runner] sourcing /shared/test.env
+[runner] waiting for approver health
+[runner] env summary:
+  HS=http://landing:80
+  SPACE_ID=!yqDFuUBzctxbQBcNZFVCvWu-MqgrzmBNcOvOTCerCIM
+  SPACE_CHILD_IDS=!bjx2DHu7uX6anC4lo-DCfdgTfcPcxToID-NwacGuwxs,!jgK-tge5ZW2x68iwT50X4L511fkMsso2eQJ3o-348js,!p6_slXy5zTpPeQPL_qbinNvDHEsr2nH9XwS_9z3n3zg
+  ADMIN_MXID=@admin:localhost:46167
+[runner] === announce_unit.py ===
+ok: no_flood_on_historical_closed_rooms
+ok: open_room_still_announced
+ok: seen_persists_across_cycles_for_open_then_closed
+ok: ghost_timeout_suppressed_but_real_timeout_announced
+all tests passed
+[runner] === self_heal_unit.py ===
+ok: env_token_works
+[u] env token /whoami failed; trying cached token
+[u] using cached token from /tmp/selfheal-cached-h3b_lw83/token
+ok: env_stale_cached_works
+[u] env token /whoami failed; trying cached token
+[u] cached token also stale; falling back to password
+[u] self-minted fresh token; device_id=DEV_A mxid=@u:t (cached_device='DEV_A'; reused=True)
+ok: both_stale_login_reuses_device
+[u] env token /whoami failed; trying cached token
+[u] self-minted fresh token; device_id=NEW_DEV mxid=@u:t (cached_device=None; reused=False)
+ok: first_run_no_cache_login_fresh
+[u] env token /whoami failed; trying cached token
+[u] cached token also stale; falling back to password
+[u] /login with cached device_id=STALE_DEV failed; retrying with fresh device
+[u] self-minted fresh token; device_id=NEW_DEV mxid=@u:t (cached_device='STALE_DEV'; reused=False)
+ok: login_with_cached_device_fails_retries_fresh
+[u] env token /whoami failed; trying cached token
+[u] no usable password at /tmp/selfheal-nopass-rcea7ihz/password; cannot self-mint
+ok: no_password_no_env_returns_none
+ok: device_changed_helper
+all tests passed
+[runner] === smoke.py ===
+smoke test against http://landing:80
+
+[signup] username=smoke_signup_1786906639_304e
+  [PASS] signup returns 200  (status=200 body={'user_id': '@smoke_signup_1786906639_304e:localhost:46167', 'access_token': '7ZnZqXvmEXla1W0VSfK1JhRbPXXivTyw', 'device_id': 'wBWCgccp8F', 'homeserver': 'http://landing:80', 'space_id': '!yqDFuUBzctxbQBcNZFVCvWu-MqgrzmBNcOvOTCerCIM', 'steps': {'register': True, 'space_invited': True, 'displayname_set': True, 'space_joined': True, 'children_joined': ['!bjx2DHu7uX6anC4lo-DCfdgTfcPcxToID-NwacGuwxs', '!jgK-tge5ZW2x68iwT50X4L511fkMsso2eQJ3o-348js', '!p6_slXy5zTpPeQPL_qbinNvDHEsr2nH9XwS_9z3n3zg'], 'inviter_dm': True}, 'dm_room': '!_8IVopa7UzDrcPkQgqU_gnVVUj8vbjlhM_o4mmDp2No', 'intro_text': 'automated smoke test — please ignore'})
+  [PASS] register step
+  [PASS] space_invited step
+  [PASS] space_joined step
+  [PASS] inviter_dm step
+  [PASS] children_joined (3/3)
+  [PASS] dm_room returned
+  [PASS] user sees space in join set
+  [PASS] user joined all 3 children
+  [PASS] user sees DM room
+
+[knock] test account: smoke_knock_1786906640_e43d
+  [PASS] knock-test account registered  (status=200)
+  [PASS] knock posted  (status=200)
+  [PASS] vetting room invite within 15s  (room=!7v-CiV4wDabNg8SbZWIvLb8_YQqwnXW5I8V_s2NIJf8)
+  [PASS] joined vetting room  (status=200)
+  [PASS] challenge keyword visible  (keyword='wikipedia')
+  [PASS] haiku sent  (status=200)
+  [PASS] space invite after vetting (within 15s)
+  [PASS] bad code: no invites at all  (invites=[])
+
+[cleanup] kicking 3 test user(s)
+
+=== 18/18 passed ===
+[runner] === vetting_e2e.py ===
+[alice] registered @e2e_alice_1786906657_3f0a:localhost:46167 device=E2EALICE24d4
+  [PASS] [alice] knock posted  (status=200)
+  [PASS] [alice] vetting room invite arrived  (room=!iB2ptFkaausPOZX6hyEGK86wP9zKnZcV_8aI6XAVYb4)
+  [PASS] [alice] joined vetting room  (status=200)
+  [PASS] [alice] captcha keyword visible  (keyword='wikipedia')
+  [PASS] [alice] haiku sent  (status=200)
+  [PASS] [alice] space invite after vetting
+  [PASS] [alice] welcome signup-code url posted in ack  (url=http://landing:80/signup?code=YJivA7yu)
+  [PASS] [alice] onboarding doc url posted in ack
+  [PASS] [alice] accepted space invite  (status=200)
+[bob] registered @e2e_bob_1786906666_69a4:localhost:46167 device=E2EBOB738d
+  [PASS] [bob] knock posted  (status=200)
+  [PASS] [bob] vetting room invite arrived  (room=!vi2QT0iglsaTEeJ_EBCBX2Bl3-LZSF1OAPFRxRLzwPM)
+  [PASS] [bob] joined vetting room  (status=200)
+  [PASS] [bob] captcha keyword visible  (keyword='wikipedia')
+  [PASS] [bob] haiku sent  (status=200)
+  [PASS] [bob] space invite after vetting
+  [PASS] [bob] welcome signup-code url posted in ack  (url=http://landing:80/signup?code=kz6vhgBa)
+  [PASS] [bob] onboarding doc url posted in ack
+  [PASS] [bob] accepted space invite  (status=200)
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+  [PASS] E2EE child room reports encrypted (alice side)
+  [PASS] E2EE child room reports encrypted (bob side)
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Didn't find cross-signing key master of @admin:localhost:46167
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Didn't find cross-signing key master of @e2e_bob_1786906666_69a4:localhost:46167
+  [PASS] alice sent encrypted message  (event_id=$A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q)
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Didn't find cross-signing key master of @e2e_alice_1786906657_3f0a:localhost:46167
+  [PASS] bob decrypted alice's message via OlmMachine  (got='vetting-e2e secret 478a1d30fab81142')
+
+=== 22/22 pass ===
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7f2685ce3150>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f2685cf5750>, 30905383.98600405), (<aiohttp.client_proto.ResponseHandler object at 0x7f2685cb7650>, 30905385.98054896)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7f2685ce34d0>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7f2685ce3750>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f2685ceb950>, 30905383.972930886)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7f2685ce2a90>
+[runner] === lobby_e2e.py ===
+  [PASS] /join/api rejects bogus code  (status=403 body={'error': 'invalid_code'})
+[alice] registered @e2e_lobby_alice_1786906678_5acc:localhost:46167 device=E2ELALICE4471
+  [PASS] [alice] /join/api returned 200  (status=200 body={'url': 'https://matrix.to/#/%23shape-rotator-lobby-sn68s6ra5p%3Alocalhost%3A46167', 'alias': '#shape-rotator-lobby-sn68s6ra5p:localhost:46167', 'room_id': '!AvwxNRXpX9ggvSDHAD:localhost:46167', 'title': 'Wikipedia', 'keyword': 'wikipedia'})
+  [PASS] [alice] /join/api returned room_id+url  (room=!AvwxNRXpX9ggvSDHAD:localhost:46167 alias=#shape-rotator-lobby-sn68s6ra5p:localhost:46167)
+  [PASS] [alice] joined lobby room via alias  (status=200 alias=#shape-rotator-lobby-sn68s6ra5p:localhost:46167)
+  [PASS] [alice] captcha keyword visible in lobby  (keyword='wikipedia')
+  [PASS] [alice] haiku sent  (status=200)
+  [PASS] [alice] space invite after lobby
+  [PASS] [alice] welcome signup-code url posted in ack  (url=http://landing:80/signup?code=nO7fDKlY)
+  [PASS] [alice] onboarding doc url posted in ack
+  [PASS] [alice] accepted space invite  (status=200)
+[bob] registered @e2e_lobby_bob_1786906692_aa19:localhost:46167 device=E2ELBOB7bba
+  [PASS] [bob] /join/api returned 200  (status=200 body={'url': 'https://matrix.to/#/%23shape-rotator-lobby-uts9tgdsrq%3Alocalhost%3A46167', 'alias': '#shape-rotator-lobby-uts9tgdsrq:localhost:46167', 'room_id': '!pKQEdDeCoCiPmhJpbM:localhost:46167', 'title': 'Wikipedia', 'keyword': 'wikipedia'})
+  [PASS] [bob] /join/api returned room_id+url  (room=!pKQEdDeCoCiPmhJpbM:localhost:46167 alias=#shape-rotator-lobby-uts9tgdsrq:localhost:46167)
+  [PASS] [bob] joined lobby room via alias  (status=200 alias=#shape-rotator-lobby-uts9tgdsrq:localhost:46167)
+  [PASS] [bob] captcha keyword visible in lobby  (keyword='wikipedia')
+  [PASS] [bob] haiku sent  (status=200)
+  [PASS] [bob] space invite after lobby
+  [PASS] [bob] welcome signup-code url posted in ack  (url=http://landing:80/signup?code=88m9Y9Fh)
+  [PASS] [bob] onboarding doc url posted in ack
+  [PASS] [bob] accepted space invite  (status=200)
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+  [PASS] E2EE child room reports encrypted (alice side)
+  [PASS] E2EE child room reports encrypted (bob side)
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Device @e2e_lobby_alice_1786906678_5acc:localhost:46167/E2ELALICE4471 isn't cross-signed
+Device @e2e_lobby_bob_1786906692_aa19:localhost:46167/E2ELBOB7bba isn't cross-signed
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Didn't find cross-signing key master of @admin:localhost:46167
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Didn't find cross-signing key master of @e2e_alice_1786906657_3f0a:localhost:46167
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Didn't find cross-signing key master of @e2e_bob_1786906666_69a4:localhost:46167
+Device @e2e_lobby_bob_1786906692_aa19:localhost:46167/E2ELBOB7bba isn't cross-signed
+Didn't find cross-signing key master of @e2e_lobby_bob_1786906692_aa19:localhost:46167
+  [PASS] alice sent encrypted message  (event_id=$4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew)
+Device @e2e_lobby_alice_1786906678_5acc:localhost:46167/E2ELALICE4471 isn't cross-signed
+Device @e2e_lobby_alice_1786906678_5acc:localhost:46167/E2ELALICE4471 isn't cross-signed
+Didn't find cross-signing key master of @e2e_lobby_alice_1786906678_5acc:localhost:46167
+  [PASS] bob decrypted alice's message via OlmMachine  (got='lobby-e2e secret ef0627c69097e1a2')
+  [PASS] [alice-redo] /join/api returned 200 for existing member  (status=200)
+  [PASS] [alice-redo] joined fresh lobby as existing member  (status=200)
+  [PASS] [alice-redo] captcha keyword visible  (keyword='wikipedia')
+  [PASS] [alice-redo] got 'already in space' ack from bot  (ack="you're already in shape rotator — see you in the space.\n\nonboarding doc: https://github.com/amiller/smithers-toys/blob/main/demos/shape-rotator-matrix-welcome.md\n\nhere's a 10-use signup code for adding accounts/agents to this server: http://landing:80/signup?code=I5zrHrH")
+
+=== 27/27 pass ===
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7faac0161b50>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7faac0174090>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7faac0179150>, 30905416.69258652)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7faac0174690>
+[runner] === admin_e2ee.py ===
+[admin_e2ee] test user: @admin_e2ee_1786906723_c4a6:localhost:46167 device=E2EEADMIN20a0
+  [PASS] bumped test user PL to 50 in admin room  (status=200)
+  [PASS] invited test user to admin room  (status=200)
+  [PASS] test user joined admin room  (status=200)
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew: Failed to decrypt megolm event: no session with given ID ZXI0xcCbOGL7kOXTdwQ1XD3RFqfD+jx25sVJJrnMsSU found
+Failed to decrypt $vl-QGjXS0dpDbbRiDMYZfmJJwhLi79rlw0cH97sgzGU: Failed to decrypt megolm event: no session with given ID yJ7rcVw092LfyFDzkCNtTbwBA8mwubT3CGhmT2GNN0s found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew: Failed to decrypt megolm event: no session with given ID ZXI0xcCbOGL7kOXTdwQ1XD3RFqfD+jx25sVJJrnMsSU found
+Failed to decrypt $vl-QGjXS0dpDbbRiDMYZfmJJwhLi79rlw0cH97sgzGU: Failed to decrypt megolm event: no session with given ID yJ7rcVw092LfyFDzkCNtTbwBA8mwubT3CGhmT2GNN0s found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+  [PASS] admin room reports encrypted
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew: Failed to decrypt megolm event: no session with given ID ZXI0xcCbOGL7kOXTdwQ1XD3RFqfD+jx25sVJJrnMsSU found
+Failed to decrypt $vl-QGjXS0dpDbbRiDMYZfmJJwhLi79rlw0cH97sgzGU: Failed to decrypt megolm event: no session with given ID yJ7rcVw092LfyFDzkCNtTbwBA8mwubT3CGhmT2GNN0s found
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Device @admin_e2ee_1786906723_c4a6:localhost:46167/E2EEADMIN20a0 isn't cross-signed
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Device @e2e_lobby_alice_1786906678_5acc:localhost:46167/E2ELALICE4471 isn't cross-signed
+Device @e2e_lobby_bob_1786906692_aa19:localhost:46167/E2ELBOB7bba isn't cross-signed
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Device @admin:localhost:46167/edVWiALQ4M isn't cross-signed
+Didn't find cross-signing key master of @admin:localhost:46167
+Failed to decrypt $4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew: Failed to decrypt megolm event: no session with given ID ZXI0xcCbOGL7kOXTdwQ1XD3RFqfD+jx25sVJJrnMsSU found
+Device @e2e_alice_1786906657_3f0a:localhost:46167/E2EALICE24d4 isn't cross-signed
+Didn't find cross-signing key master of @e2e_alice_1786906657_3f0a:localhost:46167
+Failed to decrypt $vl-QGjXS0dpDbbRiDMYZfmJJwhLi79rlw0cH97sgzGU: Failed to decrypt megolm event: no session with given ID yJ7rcVw092LfyFDzkCNtTbwBA8mwubT3CGhmT2GNN0s found
+Failed to decrypt $33SULfr3Y8eUN3Bjqq3-Zgm0TI6XenLSRTiicMoWe48: Failed to decrypt megolm event: no session with given ID R81m68ec+eXGrwWJnx+ib8f0Qwr7B+x59g39k1WxRxY found
+Failed to decrypt $TDd3Kdn_MV0psJz1afm3tkIIxztmTzpQzfIpgMv4vN0: Failed to decrypt megolm event: no session with given ID IidilIhJVJu99wSZ93Ky3nCRYjcJ95CTplDjusdzIYg found
+Device @e2e_bob_1786906666_69a4:localhost:46167/E2EBOB738d isn't cross-signed
+Didn't find cross-signing key master of @e2e_bob_1786906666_69a4:localhost:46167
+Failed to decrypt $UJhMn1zRRjBgt6ay_kU6ApwuZC_l98KcVPhF2DYasVY: Failed to decrypt megolm event: no session with given ID O853KGuyjJgjMO+sDqBnikSRAUqlq5fjdwP2YRsnS78 found
+Device @e2e_lobby_alice_1786906678_5acc:localhost:46167/E2ELALICE4471 isn't cross-signed
+Didn't find cross-signing key master of @e2e_lobby_alice_1786906678_5acc:localhost:46167
+Failed to decrypt $A7F3ZbO_UYvpAYQzjHlgu3a7-if6g-70atRe04eWS9Q: Failed to decrypt megolm event: no session with given ID smUrovLFcGqKkHvCpMORneHydssFFpDWnexfaUz0JXI found
+Failed to decrypt $9TZdMxOAlnKpfQp-B495-5EvhH55rS9pv6O6YbG4UQE: Failed to decrypt megolm event: no session with given ID ZjMyWXqNDrbg9dl1Z5AFajVegQSLzVINHcqacCKhEC8 found
+Device @e2e_lobby_bob_1786906692_aa19:localhost:46167/E2ELBOB7bba isn't cross-signed
+Didn't find cross-signing key master of @e2e_lobby_bob_1786906692_aa19:localhost:46167
+Failed to decrypt $HtT_9aOE1t7K63gC4J6orsIeNfXxleMFWc6eZLHpd44: Failed to decrypt megolm event: no session with given ID Ji/5YhyKUNBIyiVeTSFYati8NMC90kDI5irwI5W2j3g found
+Failed to decrypt $4tL2_fLzs4jyw5BG1hQ2_wRU98dRfhaeTmd3-q_Ddew: Failed to decrypt megolm event: no session with given ID ZXI0xcCbOGL7kOXTdwQ1XD3RFqfD+jx25sVJJrnMsSU found
+Failed to decrypt $vl-QGjXS0dpDbbRiDMYZfmJJwhLi79rlw0cH97sgzGU: Failed to decrypt megolm event: no session with given ID yJ7rcVw092LfyFDzkCNtTbwBA8mwubT3CGhmT2GNN0s found
+  [PASS] sent encrypted !mint command  (event_id=$62Z7YAvQ_II75m_HHxXAv8S-VvYDMpIZoinMvsb3GZM)
+Didn't find cross-signing key master of @admin:localhost:46167
+[admin_e2ee] received from @admin:localhost:46167: 'minted knock code → http://landing:80/join?code=9jfh73l\n(label: admin-e2ee-bc0591, 3 uses)'
+  [PASS] bot replied with encrypted !mint result  (body[:120]='minted knock code → http://landing:80/join?code=9jfh73l\n(label: admin-e2ee-bc0591, 3 uses)' ; all_seen=[('@admin:localhost:46167', 'minted knock code → http://landing:80/join?code=9jfh73l\n(label: admin-e2ee-bc0591, 3 uses)')])
+  [PASS] reply contains a /join URL with code  (code='9jfh73l')
+
+=== 7/7 pass ===
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7f3d98241bd0>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f3d98250650>, 30905433.275465384)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7f3d98241b50>
+[runner] === retention_room_e2e.py ===
+[retention_e2e] bot=@ret_bot_603e2a:localhost:46167 member=@ret_member_603e2a:localhost:46167 attacker=@ret_atk_603e2a:localhost:46167
+  [PASS] 1a. room created via factory (command core)  (room=!RvvV1JleM3146WB1O1:localhost:46167)
+  [PASS] 1b. !retention-room command wrapper creates a room + replies  (reply='created retention room !SBZNcdZ13nbyeHaBzu:localhost:46167\n  name:   ops-chat\n  ')
+  [PASS] 1c. !retention-room rejects missing args  (reply='usage: !retention-room <name> <duration>   (e.g. !retention-')
+  [PASS] 1d. !retention-room rejects a bad duration  (reply="!retention-room: bad duration 'bogus': expected a number")
+  [PASS] 2a. power_levels readable  (status=200)
+  [PASS] 2b. bot is PL100  (bot_pl=100)
+  [PASS] 2c. no other user at >=50 (bot is sole PL100)  (ge50={'@ret_bot_603e2a:localhost:46167': 100})
+  [PASS] 2d. users_default == 0  (users_default=0)
+  [PASS] 3a. m.room.encryption present (megolm)  (200 {'algorithm': 'm.megolm.v1.aes-sha2'})
+  [PASS] 3b. m.room.retention present with window (ms)  (200 {'max_lifetime': 604800000})
+  [PASS] 4a. exactly one event pinned  (pinned=['$kwgjyt3cHpBldah9kLeIYsj0PMbGwaYZmLYh2r9g_Mc'])
+  [PASS] 4b. pinned text mentions the configured window  (label='1w' body[:80]='📜 Retention policy — immutable at room creation\n\nRoom: standup\nPolicy window: 1w')
+  [PASS] 4c. pinned text is honest (states what it does NOT do)  (body[:120]='📜 Retention policy — immutable at room creation\n\nRoom: standup\nPolicy window: 1w (604800s)\n\nWhat this DOES: the bot (sol')
+  [PASS] 4d. pinned text equals bot policy_text for this window
+  [PASS] 5a. room is linked as a space child (m.space.child present)  (200 {'via': ['landing:80']})
+  [PASS] 5b. join_rule restricted to the space  ({'allow': [{'room_id': '!zDnIXG_vR5aYfVCCN0Zx_r7-tMVyhCn7eJ5x9R6tadc', 'type': 'm.room_membership'}], 'join_rule': 'restricted'})
+  [PASS] 5c. space member joined retention room with NO invite  (status=200)
+  [PASS] 6a. elevated attacker to PL100 (simulated)  (status=200)
+  [PASS] 6b. attacker PUT of m.room.retention accepted by server  (status=200 body={'event_id': '$cWzl0R2VkfLPemBINKYRG1P4duQTR2wfYhRB7lerwkU'})
+  [PASS] 6c. room state DID change (proves the PUT landed)  (room_state={'max_lifetime': 86400000})
+  [PASS] 6d. bot in-force window UNCHANGED (immutable store)  (in_force_window=604800 in_force_ms=604800000)
+
+=== 21/21 pass ===
+[runner] === escrow_durability.py ===
+[escrow] bot=@esc_bot_1786906726_3a8e:localhost:46167 (devs BOT_A_4f10 -> BOT_B_69f2) alice=@esc_alice_1786906726_3a8e:localhost:46167
+[escrow] room=!4d2_3KWQxgeVddzsyMFBgJ4_VV8040hW-EiuHqskKAI
+Device @esc_alice_1786906726_3a8e:localhost:46167/ALICE4f9e isn't cross-signed
+Device @esc_bot_1786906726_3a8e:localhost:46167/BOT_A_4f10 isn't cross-signed
+Device @esc_bot_1786906726_3a8e:localhost:46167/BOT_A_4f10 isn't cross-signed
+Didn't find cross-signing key master of @esc_bot_1786906726_3a8e:localhost:46167
+[escrow] pre-wipe msg id=$9REY2o_PG5TeHxIwPxStXU64a1G3pyI4vw4on6-2dOY body='history-must-survive-d9590c79'
+Device @esc_alice_1786906726_3a8e:localhost:46167/ALICE4f9e isn't cross-signed
+Device @esc_alice_1786906726_3a8e:localhost:46167/ALICE4f9e isn't cross-signed
+Didn't find cross-signing key master of @esc_alice_1786906726_3a8e:localhost:46167
+  [PASS] bot device A decrypts the message (inbound session present)
+  [PASS] export_inbound_sessions dumps the inbound megolm session(s)  (1 session(s) -> inbound_sessions.escrow.json)
+[self-heal] removed /tmp/escrow_1786906726_3a8e/bot_crypto.db
+  [PASS] _wipe_crypto_store deletes bot_crypto.db  (fresh store on next open)
+  [PASS] without escrow, wiped store cannot decrypt (the bug #60 fixes)  (SessionNotFound after wipe)
+[self-heal] removed /tmp/escrow_1786906726_3a8e/bot_crypto.db
+  [PASS] re-mint logs the bot in under a NEW device_id  (BOT_A_4f10 -> BOT_B_69f2)
+  [PASS] import_inbound_sessions restores the escrowed session(s)  (1/1 restored)
+Device @esc_alice_1786906726_3a8e:localhost:46167/ALICE4f9e isn't cross-signed
+Device @esc_alice_1786906726_3a8e:localhost:46167/ALICE4f9e isn't cross-signed
+Didn't find cross-signing key master of @esc_alice_1786906726_3a8e:localhost:46167
+  [PASS] re-minted bot (new device) decrypts the pre-wipe message  (body='history-must-survive-d9590c79')
+  [PASS] escrow file is retained after import (durable across wipes)
+
+[escrow] 8/8 checks passed
+[runner] === history_bundle_e2e.py ===
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Device @bundle_bot_30905434_b6f8:localhost:46167/BBOT22bb isn't cross-signed
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Device @bundle_bot_30905434_b6f8:localhost:46167/BBOT22bb isn't cross-signed
+Didn't find cross-signing key master of @bundle_bot_30905434_b6f8:localhost:46167
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Didn't find cross-signing key master of @bundle_carol_30905434_b6f8:localhost:46167
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Device @bundle_bot_30905434_b6f8:localhost:46167/BBOT22bb isn't cross-signed
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Didn't find cross-signing key master of @bundle_alice_30905434_b6f8:localhost:46167
+Device @bundle_bot_30905434_b6f8:localhost:46167/BBOT22bb isn't cross-signed
+Didn't find cross-signing key master of @bundle_bot_30905434_b6f8:localhost:46167
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Didn't find cross-signing key master of @bundle_alice_30905434_b6f8:localhost:46167
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Didn't find cross-signing key master of @bundle_carol_30905434_b6f8:localhost:46167
+Failed to decrypt $EVwQiF7rumX1rwcbVFn_59KlUsjlmwhRizIZ_VRlCY4: Failed to decrypt megolm event: no session with given ID QlNwBlz7i79bahOg5j77OjlnalIw23bcCBEbezqA1Ks found
+Failed to decrypt $jZ459SAPmwzwMjUupkW3Gy8jKBNrFrfrJhWlzrNvSo0: Failed to decrypt megolm event: no session with given ID wDIAug+AFm2SnMg+s1Fx7sSpdMzlskOp8YE9KKKP58s found
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Device @bundle_alice_30905434_b6f8:localhost:46167/BALICE6d9d isn't cross-signed
+Didn't find cross-signing key master of @bundle_alice_30905434_b6f8:localhost:46167
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Device @bundle_carol_30905434_b6f8:localhost:46167/BCAROL5d81 isn't cross-signed
+Didn't find cross-signing key master of @bundle_carol_30905434_b6f8:localhost:46167
+MSC4268 bundle round-trip: 2 sessions exported, uploaded, downloaded, imported, decrypted
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7ffb21786510>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7ffb2178d1d0>, 30905434.95473943)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7ffb21786450>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7ffb21785e10>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7ffb22ca9150>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7ffb2175b6d0>, 30905434.99221202)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7ffb21786810>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7ffb2175bbd0>, 30905441.004006952), (<aiohttp.client_proto.ResponseHandler object at 0x7ffb2178e250>, 30905444.00736337)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7ffb217a73d0>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7ffb20443ad0>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7ffb203df650>, 30905444.122258324)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7ffb201f3c10>
+[runner] === sas_e2e.py === (informational; failures don't gate the PR)
+bot=@bot_1786906736:localhost:46167 verifier=@ver_1786906736:localhost:46167
+bot pid=56 log=/tmp/sas_e2e_1786906736/responder.log
+verifier sent .start tx=t-f405b56a69a8
+result: success=True trust=verified cancel_reason=None
+PASS
+[runner] sas_e2e: PASS
+[runner] === history_bundle_responder_e2e.py ===
+Device @bundle_alice_28e2799c:localhost:46167/AL28e2799c isn't cross-signed
+Device @bundle_bot_28e2799c:localhost:46167/BO28e2799c isn't cross-signed
+Device @bundle_bot_28e2799c:localhost:46167/BO28e2799c isn't cross-signed
+Didn't find cross-signing key master of @bundle_bot_28e2799c:localhost:46167
+Device @bundle_alice_28e2799c:localhost:46167/AL28e2799c isn't cross-signed
+joined invite !Rj3tQCtbvJCIm3n4PTNHfW6JraNXyMOcZaYAtzxQ9vo
+Device @bundle_alice_28e2799c:localhost:46167/AL28e2799c isn't cross-signed
+Didn't find cross-signing key master of @bundle_alice_28e2799c:localhost:46167
+Device @bundle_bob_28e2799c:localhost:46167/BB28e2799c isn't cross-signed
+rejected m.room_key_bundle from non-inviter sender=@outsider:localhost room=!Rj3tQCtbvJCIm3n4PTNHfW6JraNXyMOcZaYAtzxQ9vo inviter=@bundle_bot_28e2799c:localhost:46167
+Device @bundle_alice_28e2799c:localhost:46167/AL28e2799c isn't cross-signed
+Device @bundle_alice_28e2799c:localhost:46167/AL28e2799c isn't cross-signed
+Didn't find cross-signing key master of @bundle_alice_28e2799c:localhost:46167
+MSC4268 responder E2E: inviter bundle imported; outsider rejected; pre-join message decrypted
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7fc91c79fbd0>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7fc91c7a2b50>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7fc91c79a1d0>, 30905451.116442505)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7fc91c79ca10>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7fc91c79bd50>, 30905451.161186617)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7fc91c7a2bd0>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7fc91c7b0910>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7fc91c799e50>, 30905451.175781198)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7fc91c7b0a90>
+[runner] === history_bundle_invite_e2e.py ===
+[invite-e2e] alice=@inv_alice_1786906743_4499:localhost:46167 bot=@inv_bot_1786906743_4499:localhost:46167
+[invite-e2e] room=!1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8
+Device @inv_alice_1786906743_4499:localhost:46167/AL8eb8 isn't cross-signed
+Device @inv_bot_1786906743_4499:localhost:46167/BOT34ab isn't cross-signed
+Device @inv_bot_1786906743_4499:localhost:46167/BOT34ab isn't cross-signed
+Didn't find cross-signing key master of @inv_bot_1786906743_4499:localhost:46167
+Device @inv_alice_1786906743_4499:localhost:46167/AL8eb8 isn't cross-signed
+Device @inv_alice_1786906743_4499:localhost:46167/AL8eb8 isn't cross-signed
+Didn't find cross-signing key master of @inv_alice_1786906743_4499:localhost:46167
+Didn't find cross-signing key master of @inv_alice_1786906743_4499:localhost:46167
+  [PASS] bot decrypts alice's pre-invite message (inbound session present)
+  [PASS] endorser resolved from the code's minted_by  (@inv_alice_1786906743_4499:localhost:46167)
+Device @inv_bob_1786906743_4499:localhost:46167/BBf15d isn't cross-signed
+[room_key_bundle] sent to 1 device(s) of @inv_bob_1786906743_4499:localhost:46167 for room=!1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8
+  [PASS] approver._invite_to_children invited the child room  (['!1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8'])
+joined invite !1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8
+  [PASS] bob auto-joined the room after the invite
+  [PASS] bob's client can fetch the pre-invite event
+Device @inv_alice_1786906743_4499:localhost:46167/AL8eb8 isn't cross-signed
+Device @inv_alice_1786906743_4499:localhost:46167/AL8eb8 isn't cross-signed
+Didn't find cross-signing key master of @inv_alice_1786906743_4499:localhost:46167
+  [PASS] bob decrypts alice's PRE-INVITE message via the imported bundle  (body='pre-invite history c51ce7df')
+  [PASS] endorsement JSONL contains the (endorser, invitee, code, room_id) edge  ({'endorser': '@inv_alice_1786906743_4499:localhost:46167', 'invitee': '@inv_bob_1786906743_4499:localhost:46167', 'code_or_manual': 'testcode', 'room_id': '!1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8', 'ts': 1786906752.8341353})
+  [PASS] endorsement edge names alice as endorser (code minted_by) and the right code  ({'endorser': '@inv_alice_1786906743_4499:localhost:46167', 'invitee': '@inv_bob_1786906743_4499:localhost:46167', 'code_or_manual': 'testcode', 'room_id': '!1PeFkT1G7M8IzzkmklhhCBDPK7dWuulsvy__n8l0Zc8', 'ts': 1786906752.8341353})
+
+[invite-e2e] 8/8 checks passed
+[runner] all gating tests passed
+[run_e2e] tearing down stack
+ Container shape-rotator-e2e-751775899-landing-1  Stopping
+ Container shape-rotator-e2e-751775899-landing-1  Stopped
+ Container shape-rotator-e2e-751775899-landing-1  Removing
+ Container shape-rotator-e2e-751775899-landing-1  Removed
+ Container shape-rotator-e2e-751775899-knock-approver-1  Stopping
+ Container shape-rotator-e2e-751775899-knock-approver-1  Stopped
+ Container shape-rotator-e2e-751775899-knock-approver-1  Removing
+ Container shape-rotator-e2e-751775899-knock-approver-1  Removed
+ Container shape-rotator-e2e-751775899-bootstrap-1  Stopping
+ Container shape-rotator-e2e-751775899-bootstrap-1  Stopped
+ Container shape-rotator-e2e-751775899-bootstrap-1  Removing
+ Container shape-rotator-e2e-751775899-bootstrap-1  Removed
+ Container shape-rotator-e2e-751775899-continuwuity-1  Stopping
+ Container shape-rotator-e2e-751775899-continuwuity-1  Stopped
+ Container shape-rotator-e2e-751775899-continuwuity-1  Removing
+ Container shape-rotator-e2e-751775899-continuwuity-1  Removed
+ Volume shape-rotator-e2e-751775899_shared  Removing
+ Volume shape-rotator-e2e-751775899_knock-test-data  Removing
+ Volume shape-rotator-e2e-751775899_continuwuity-test-data  Removing
+ Network shape-rotator-e2e-751775899_default  Removing
+ Volume shape-rotator-e2e-751775899_continuwuity-test-data  Removed
+ Volume shape-rotator-e2e-751775899_shared  Removed
+ Volume shape-rotator-e2e-751775899_knock-test-data  Removed
+ Network shape-rotator-e2e-751775899_default  Removed

--- a/.evidence/issue-7/flow.md
+++ b/.evidence/issue-7/flow.md
@@ -1,0 +1,85 @@
+# Issue #7 — Matrix admin moderation surface (`!kick` / `!ban` / `!unban` / `!stats`) — PR #68 evidence
+
+Branch `ready-7`, head `e1f6c23` (rebased onto `staging` @ `b0d713d` by the rework lane
+2026-08-16; conflicts in `knock-approver/approver.py` + `PLAN.md` resolved preserving both
+intents — retention-room factory from #87/#88 kept, this PR's moderation block appended).
+
+## Tier classification (and why not the generic forms)
+
+Changed files: `README.md`, `deploy/admin/README.md`, `knock-approver/approver.py`.
+
+- The approver is a **mautrix-python client** — it serves no HTTP routes. This repo has no
+  `/_api/version` endpoint (`grep -rniE '_api/version'` → empty; same finding as merged #67
+  and #88), so the generic Tier-1 anchor ("HTTP transcript + `/_api/version` pinned") is
+  structurally inapplicable to this repo. What the anchor exists to prove — that the behavior
+  ran against the real deployed environment — is pinned here by a **live read-only call
+  against the deployed staging homeserver** (`staging_anchor.txt`), the same substitute the
+  gate accepted for #88.
+- The behavior IS visible to humans (admins see command replies in their Matrix client), but
+  the repo owns no web UI to screenshot and this box has no Matrix real-browser rig; the
+  gate's file-based tier for this diff is the api/Tier-1 branch, satisfied below by driving
+  the commands end-to-end over the Matrix client-server API (the exact HTTP surface the
+  change rides on), encrypted, against a real homeserver running this branch's code.
+- NOT declared Tier 0: this diff adds real behavior (four new commands). Tier 0 is for
+  zero-behavior-change diffs and is not claimed here.
+
+## What was run (all on head `e1f6c23` in a clean worktree)
+
+1. **Standing PR gate** — `bash tests/run_e2e.sh`: **all gating tests passed**
+   (`e2e_gate_transcript.txt`; includes `admin_e2ee.py` 7/7 `!mint` E2EE and
+   `retention_room_e2e.py` 21/21, the landed block this PR's code now sits beside).
+2. **New-command drive** — `.evidence/issue-7/drive_admin_moderation.py` (committed,
+   reproducible) spins up the same docker stack, then: three fresh users (PL-50 admin `A`,
+   PL-0 `N`, victim `V`), each admin sender a real mautrix client with OlmMachine +
+   PgCryptoStore, commands sent **encrypted** into the encrypted admin command room, replies
+   decrypted and asserted, and `V`'s space membership verified **independently** over the
+   client-server HTTP API. **15/15 pass** (`moderation_e2ee_transcript.txt` + the
+   knock-approver container's own `[admin] dispatch … is_admin=…` lines).
+3. **Live staging anchor** — read-only GETs vs `https://mtrx.shaperotator.xyz`:
+   `/_matrix/client/versions` → HTTP 200, and the space alias resolves to
+   `!4FL8uL5OEYLATG1VH4wC2CD3pfIV6BMFId9VT7rmm-g` — the same room ID recorded in merged
+   #88's evidence, i.e. the exact room the new `/_matrix/client/v3/rooms/{space}/(kick|ban|unban)`
+   calls will act on in the deployed environment (`staging_anchor.txt`).
+
+## Acceptance of issue #7, asserted line by line
+
+- `!mint` (knock + signup) implemented and gates on PL — **pre-existing on staging**, not in
+  this diff; re-proven by the gate's `admin_e2ee.py` (7/7) on this head. The PL gate itself
+  is additionally proven live for the NEW commands by the `N` (PL 0) refusal below.
+- `!codes` and `!revoke` implemented — pre-existing on staging, not in this diff.
+- `!ban` / `!kick` / `!unban` implemented — **driven live, encrypted**: bot replies
+  `kicked/banned/unbanned @mod_victim…:localhost:46167 from the space`, and the victim's
+  membership was verified over the client-server API to go `join → leave` (kick), `→ ban`
+  (ban), `→ leave` (unban). Guards proven too: bare `!kick` → usage line; `!kick @admin`
+  → "refused: I will not kick myself"; PL-0 user → "refused — need PL >= 50 or be on the
+  allowlist" (also visible in the bot's own dispatch log: `is_admin=False`).
+- `!stats` reads from audit log, returns aggregate counts + top captcha keywords — driven
+  live twice (before/after moderation traffic):
+  `last 24h: knocks=0, promoted=0, rejected=0, pending=0` + `top captcha keywords: none`.
+  Honest limit: the stack was fresh, so the keyword list is the EMPTY state — aggregation
+  over populated keyword events was covered by the PR's focused handler checks, not by this
+  live drive.
+- E2EE-ness decision recorded + `deploy/admin/README.md` co-admin handoff — doc additions in
+  this diff (`README.md`, `deploy/admin/README.md`, +25 lines).
+
+## What could NOT be verified (unchanged from the PR body, still true)
+
+- No Matrix real-browser rig on this box → no signed-in screenshots of a human's Matrix
+  client; the E2EE command round-trips above are the same wire behavior a client renders.
+- The deployed staging approver runs MERGED staging code only, so unmerged commands cannot
+  be driven against the deployment itself (pre-merge); the anchor pins the deployed
+  environment instead.
+
+## Repro
+
+```
+git worktree add /tmp/rw-68 ready-7 && cd /tmp/rw-68/tests
+bash run_e2e.sh                                   # gate
+# then the single-bootstrap dance from run_e2e.sh, and:
+docker compose -f docker-compose.test.yml -p shape-rotator-e2e run -T --rm test-runner sh -c '
+  set -a; . /shared/test.env; set +a; export HS=http://landing:80
+  DEV_HS="$HS" DEV_REG_TOKEN="$CONDUWUIT_REGISTRATION_TOKEN" \
+  ADMIN_COMMAND_ROOM="$ADMIN_COMMAND_ROOM" ADMIN_TOKEN="$ADMIN_TOKEN" \
+  ADMIN_MXID="$ADMIN_MXID" SPACE_ID="$SPACE_ID" \
+  python3 .evidence/issue-7/drive_admin_moderation.py'
+```

--- a/.evidence/issue-7/moderation_e2ee_transcript.txt
+++ b/.evidence/issue-7/moderation_e2ee_transcript.txt
@@ -1,0 +1,128 @@
+ Container shape-rotator-e2e-continuwuity-1  Running
+ Container shape-rotator-e2e-bootstrap-1  Created
+ Container shape-rotator-e2e-knock-approver-1  Running
+ Container shape-rotator-e2e-landing-1  Running
+ Container shape-rotator-e2e-bootstrap-1  Starting
+ Container shape-rotator-e2e-bootstrap-1  Started
+ Container shape-rotator-e2e-bootstrap-1  Waiting
+ Container shape-rotator-e2e-bootstrap-1  Exited
+[driver] e2ee user: @mod_admin_1786908728_a954:localhost:46167 device=DRVa554
+  [PASS] A bumped to PL 50 in admin command room  (status=200)
+[driver] e2ee user: @mod_pleb_1786908728_4959:localhost:46167 device=DRV26c3
+[driver] victim user: @mod_victim_1786908729_395f:localhost:46167
+  [PASS] admin command room is E2EE for A
+Device @admin:localhost:46167/zUnOImd31Y isn't cross-signed
+Device @mod_admin_1786908728_a954:localhost:46167/DRVa554 isn't cross-signed
+Device @mod_pleb_1786908728_4959:localhost:46167/DRV26c3 isn't cross-signed
+Device @admin:localhost:46167/zUnOImd31Y isn't cross-signed
+Didn't find cross-signing key master of @admin:localhost:46167
+Device @mod_pleb_1786908728_4959:localhost:46167/DRV26c3 isn't cross-signed
+Didn't find cross-signing key master of @mod_pleb_1786908728_4959:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!stats' as $Zj2SUQxqZayv8WllWmhJHQY3AkKUvHtJIQlThrnn6_w
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none'
+  [PASS] !stats (A) returns report (knocks/promoted/rejected/pending + keywords)  (reply='last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none')
+Device @mod_admin_1786908728_a954:localhost:46167/DRVa554 isn't cross-signed
+Device @admin:localhost:46167/zUnOImd31Y isn't cross-signed
+Device @mod_admin_1786908728_a954:localhost:46167/DRVa554 isn't cross-signed
+Didn't find cross-signing key master of @mod_admin_1786908728_a954:localhost:46167
+[driver] @mod_pleb_1786908728_4959:localhost:46167 received from @mod_admin_1786908728_a954:localhost:46167: '!stats'
+Device @admin:localhost:46167/zUnOImd31Y isn't cross-signed
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_pleb_1786908728_4959:localhost:46167 received from @admin:localhost:46167: 'last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none'
+  [PASS] N decrypted live bot traffic in the room (pre-send device discovery)  (inbox=[('@mod_admin_1786908728_a954:localhost:46167', '!stats'), ('@admin:localhost:46167', 'last 24h: knocks=0, promoted=0, rejected')])
+Didn't find cross-signing key master of @admin:localhost:46167
+Didn't find cross-signing key master of @mod_admin_1786908728_a954:localhost:46167
+Device @admin:localhost:46167/zUnOImd31Y isn't cross-signed
+Device @mod_admin_1786908728_a954:localhost:46167/DRVa554 isn't cross-signed
+Device @mod_pleb_1786908728_4959:localhost:46167/DRV26c3 isn't cross-signed
+[driver] @mod_pleb_1786908728_4959:localhost:46167 sent (encrypted) '!stats' as $7bLGMSLM3k7E2Pcm91af_ctFpsQk22On8KkCMLdejpA
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_pleb_1786908728_4959:localhost:46167 received from @admin:localhost:46167: '@mod_pleb_1786908728_4959:localhost:46167: refused — need PL >= 50 or be on the allowlist'
+  [PASS] PL gate: non-admin refused  (reply='@mod_pleb_1786908728_4959:localhost:46167: refused — need PL >= 50 or be on the allowlist'; inbox=[('@mod_admin_1786908728_a954:localhost:46167', '!stats'), ('@admin:localhost:46167', 'last 24h: knocks=0, promoted=0, rejected'), ('@admin:localhost:46167', '@mod_pleb_1786908728_4959:localhost:4616')])
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!kick' as $czP5cskZV0DC6V6gpT8EIbpFxDV_g-8EuKwerapUd9E
+Didn't find cross-signing key master of @mod_pleb_1786908728_4959:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @mod_pleb_1786908728_4959:localhost:46167: '!stats'
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: '@mod_pleb_1786908728_4959:localhost:46167: refused — need PL >= 50 or be on the allowlist'
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'usage: !kick <@user:server> [reason]'
+  [PASS] usage guard: bare !kick answered with usage  (reply='usage: !kick <@user:server> [reason]')
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!kick @admin:localhost:46167' as $DxAuu9YCcDdgzuplY1CuA7mKKHSRH77h4tJEv1mUmMk
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'refused: I will not kick myself'
+  [PASS] self-guard: bot refuses !kick of itself  (reply='refused: I will not kick myself')
+  [PASS] victim joined the space (pre-state)  (membership=join)
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!kick @mod_victim_1786908729_395f:localhost:46167 evidence-driver kick test' as $j4GFNpNZtZQb5vdAYuzbOmBI7Z8qEcTGhxbUeTTaYL8
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'kicked @mod_victim_1786908729_395f:localhost:46167 from the space'
+  [PASS] !kick removes a member (bot reply)  (reply='kicked @mod_victim_1786908729_395f:localhost:46167 from the space')
+  [PASS] !kick verified over client-server API  (membership=leave)
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!ban @mod_victim_1786908729_395f:localhost:46167 evidence-driver ban test' as $y0vJVwSsf5P_rH9IsSyG2USNyYigjhbL8YJ6UXOW8U8
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'banned @mod_victim_1786908729_395f:localhost:46167 from the space'
+  [PASS] !ban bans the user (bot reply)  (reply='banned @mod_victim_1786908729_395f:localhost:46167 from the space')
+  [PASS] !ban verified over client-server API  (membership=ban)
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!unban @mod_victim_1786908729_395f:localhost:46167 evidence-driver unban test' as $lDXj575Hbj7UwwQgIrGY9ZGy5jyupO9vD6qRwdSYwZM
+Didn't find cross-signing key master of @admin:localhost:46167
+[driver] @mod_admin_1786908728_a954:localhost:46167 received from @admin:localhost:46167: 'unbanned @mod_victim_1786908729_395f:localhost:46167 from the space'
+  [PASS] !unban lifts the ban (bot reply)  (reply='unbanned @mod_victim_1786908729_395f:localhost:46167 from the space')
+  [PASS] !unban verified over client-server API  (membership=leave)
+[driver] @mod_admin_1786908728_a954:localhost:46167 sent (encrypted) '!stats' as $iue3wUlX4dc8CT4GIU4iUcIaivdd1OE2dYoaxJ8SeU0
+  [PASS] !stats still well-formed after moderation traffic  (reply='last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none')
+Failed to run handler
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.11/site-packages/mautrix/client/syncer.py", line 265, in _catch_errors
+    await handler(data)
+  File "/usr/local/lib/python3.11/site-packages/mautrix/client/encryption_manager.py", line 182, in handle
+    decrypted = await self.client.crypto.decrypt_megolm_event(evt)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.11/site-packages/mautrix/crypto/decrypt_megolm.py", line 60, in decrypt_megolm_event
+    if not await self.crypto_store.validate_message_index(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.11/site-packages/mautrix/crypto/store/asyncpg/store.py", line 496, in validate_message_index
+    row = await self.db.fetchrow(
+          ^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.11/site-packages/mautrix/util/async_db/database.py", line 176, in fetchrow
+    async with self.acquire() as conn:
+  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
+    return await anext(self.gen)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.11/site-packages/mautrix/util/async_db/database.py", line 146, in acquire
+    async with self.acquire_direct() as conn:
+  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
+    return await anext(self.gen)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.11/site-packages/mautrix/util/async_db/aiosqlite.py", line 202, in _acquire
+    raise RuntimeError("database pool has been stopped")
+RuntimeError: database pool has been stopped
+
+=== 15/15 pass ===
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7f5cc153f590>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f5cc154db50>, 30907441.32129123), (<aiohttp.client_proto.ResponseHandler object at 0x7f5cc153b850>, 30907443.32501247)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7f5cc153c4d0>
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x7f5cc152d6d0>
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x7f5cc1538b50>, 30907453.453787517)])']
+connector: <aiohttp.connector.TCPConnector object at 0x7f5cc152e7d0>
+DRIVER_EXIT=0
+
+=== knock-approver container log, [admin] dispatch/reply lines (bot-side view) ===
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !stats from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !stats from @mod_pleb_1786908728_4959:localhost:46167 is_admin=False
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !kick from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'usage: !kick <@user:server> [reason]'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !kick from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'refused: I will not kick myself'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !kick from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'kicked @mod_victim_1786908729_395f:localhost:46167 from the space'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !ban from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'banned @mod_victim_1786908729_395f:localhost:46167 from the space'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !unban from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'unbanned @mod_victim_1786908729_395f:localhost:46167 from the space'
+shape-rotator-e2e-knock-approver-1  | [admin] dispatch !stats from @mod_admin_1786908728_a954:localhost:46167 is_admin=True
+shape-rotator-e2e-knock-approver-1  | [admin] sending reply: 'last 24h: knocks=0, promoted=0, rejected=0, pending=0\ntop captcha keywords: none'

--- a/.evidence/issue-7/staging_anchor.txt
+++ b/.evidence/issue-7/staging_anchor.txt
@@ -1,0 +1,11 @@
+# Live read-only anchor vs deployed staging homeserver — 2026-08-16 19:33:04Z
+# PR #68 head: e1f6c230986debc4fd0c36a25b4b833411c55f82  (branch ready-7)
+
+$ curl -sS -o - -w "\nHTTP %{http_code}\n" https://mtrx.shaperotator.xyz/_matrix/client/versions
+{"versions":["r0.0.1","r0.1.0","r0.2.0","r0.3.0","r0.4.0","r0.5.0","r0.6.0","r0.6.1","v1.1","v1.2","v1.3","v1.4","v1.5","v1.8","v1.11","v1.12","v1.13","v1.14"],"unstable_features":{"org.matrix.e2e_cross_signing":true,"org.matrix.msc2285.stable":true,"org.matrix.msc2836":true,"org.matrix.msc2946":true,"org.matrix.msc3026.busy_presence":true,"org.matrix.msc3814":true,"org.matrix.msc3827":true,"org.matrix.msc3916.stable":true,"org.matrix.msc3952_intentional_mentions":true,"org.matrix.msc4155":true,"org.matrix.msc4180":true,"org.matrix.simplified_msc3575":true,"uk.half-shot.msc2666.query_mutual_rooms":true,"uk.tcpip.msc4133":true,"uk.timedout.msc4323":true,"us.cloke.msc4175":true}}
+HTTP 200
+
+$ curl -sS -o - -w "\nHTTP %{http_code}\n" "https://mtrx.shaperotator.xyz/_matrix/client/v3/directory/room/%23shape-rotator%3Amtrx.shaperotator.xyz"
+{"room_id":"!4FL8uL5OEYLATG1VH4wC2CD3pfIV6BMFId9VT7rmm-g","servers":["gitter.im","matrix.org","mtrx.shaperotator.xyz","unredacted.org"]}
+HTTP 200
+

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ File format:
 
 All approvals and rejections are appended to `/data/log.jsonl`.
 
+## Admin command room and E2EE decision
+
+Issue #7 uses the mautrix-based approver for the admin command room, so the room
+may be encrypted; the bot decrypts incoming commands and encrypts its replies.
+This is the v1 decision rather than requiring a special cleartext admin room.
+Each human admin uses their own MXID and must have power level 50 or higher.
+Commands are limited to the configured room, while `!kick`, `!ban`, and `!unban`
+apply to the Shape Rotator space. `!stats` reports the last 24 hours from the
+approver audit log and current vetting/lobby state.
+
 ## Secrets that belong in .env
 
 - `NAMECHEAP_USERNAME`, `NAMECHEAP_API_KEY` — DNS-01 for Let's Encrypt

--- a/deploy/admin/README.md
+++ b/deploy/admin/README.md
@@ -30,3 +30,18 @@ Scripts here:
   files-in-repo containing values.
 - Validate before mutating (e.g. `/whoami` before pushing the token).
 - Are idempotent — running twice is the same as once.
+
+## Co-admin handoff
+
+Invite each helper's own Matrix account to the Shape Rotator space and set its
+power level to 50 or higher. The helper then uses that MXID in the configured
+admin room; no shared bot token is needed.
+
+The v1 admin room is handled by the mautrix-based approver and may be encrypted.
+The bot decrypts commands and encrypts replies using its persisted crypto store;
+keep that store on the `/data` volume and never reuse its device ID with a fresh
+store. Cleartext rooms use the same command surface.
+
+Supported commands are `!mint`, `!codes`, `!revoke`, `!kick`, `!ban`, `!unban`,
+and `!stats`. Moderation commands target the Shape Rotator space. Audit entries
+remain in `/data/log.jsonl`.

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -1799,11 +1799,116 @@ async def cmd_retention_room(client, room_id, sender, args):
             f"space-child of {SPACE_ID}")
 
 
+def _parse_admin_target(args, command):
+    parts = args.split(maxsplit=1)
+    if not parts or not parts[0].startswith("@") or ":" not in parts[0]:
+        return None, f"usage: {command} <@user:server> [reason]"
+    return parts[0], (parts[1].strip() if len(parts) > 1 else "admin command")
+
+
+async def _membership_action(client, action, user_id, reason="admin command"):
+    try:
+        await client.api.request(
+            "POST",
+            f"/_matrix/client/v3/rooms/{urllib.parse.quote(SPACE_ID, safe='')}/{action}",
+            content={"user_id": user_id, "reason": reason},
+        )
+    except Exception as e:
+        status = getattr(e, "http_status", None)
+        detail = str(e)[:200]
+        return False, f"{status}: {detail}" if status else detail
+    return True, "ok"
+
+
+async def cmd_kick(client, room_id, sender, args):
+    user_id, reason = _parse_admin_target(args, "!kick")
+    if not user_id:
+        return reason
+    if user_id == OUR_MXID:
+        return "refused: I will not kick myself"
+    ok, detail = await _membership_action(client, "kick", user_id, reason)
+    audit({"type": "admin_kick", "target": user_id, "reason": reason,
+           "requested_by": sender, "ok": ok, "detail": detail})
+    return f"kicked {user_id} from the space" if ok else f"!kick failed: {detail}"
+
+
+async def cmd_ban(client, room_id, sender, args):
+    user_id, reason = _parse_admin_target(args, "!ban")
+    if not user_id:
+        return reason
+    if user_id == OUR_MXID:
+        return "refused: I will not ban myself"
+    ok, detail = await _membership_action(client, "ban", user_id, reason)
+    audit({"type": "admin_ban", "target": user_id, "reason": reason,
+           "requested_by": sender, "ok": ok, "detail": detail})
+    return f"banned {user_id} from the space" if ok else f"!ban failed: {detail}"
+
+
+async def cmd_unban(client, room_id, sender, args):
+    user_id, reason = _parse_admin_target(args, "!unban")
+    if not user_id:
+        return reason
+    ok, detail = await _membership_action(client, "unban", user_id, reason)
+    audit({"type": "admin_unban", "target": user_id, "reason": reason,
+           "requested_by": sender, "ok": ok, "detail": detail})
+    return f"unbanned {user_id} from the space" if ok else f"!unban failed: {detail}"
+
+
+def _stats_last_24h():
+    cutoff = time.time() - 24 * 60 * 60
+    counts = {"knocks": 0, "promoted": 0, "rejected": 0}
+    keywords = {}
+    try:
+        lines = LOG_PATH.read_text().splitlines()
+    except FileNotFoundError:
+        lines = []
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        try:
+            event_ts = float(event.get("ts", 0))
+        except (TypeError, ValueError):
+            continue
+        if event_ts < cutoff:
+            continue
+        kind = event.get("type")
+        if kind in ("vetting_room_created", "knock_rejected"):
+            counts["knocks"] += 1
+        if kind in ("promoted", "lobby_promoted"):
+            counts["promoted"] += 1
+        if kind in ("knock_rejected", "vetting_failed", "vetting_timeout",
+                    "lobby_rejected", "lobby_failed", "lobby_timeout"):
+            counts["rejected"] += 1
+        keyword = event.get("keyword")
+        if keyword and kind in ("vetting_room_created", "lobby_challenge_sent"):
+            keywords[keyword] = keywords.get(keyword, 0) + 1
+    pending = 0
+    for path in (VETTING_PATH, LOBBY_PATH):
+        state = _load(path)
+        pending += sum(1 for meta in state.values()
+                       if not meta.get("closed") and not meta.get("promoted"))
+    top = ", ".join(f"{word} ({n})" for word, n in
+                     sorted(keywords.items(), key=lambda item: (-item[1], item[0]))[:5])
+    return (f"last 24h: knocks={counts['knocks']}, promoted={counts['promoted']}, "
+            f"rejected={counts['rejected']}, pending={pending}\n"
+            f"top captcha keywords: {top or 'none'}")
+
+
+async def cmd_stats(client, room_id, sender, args):
+    return _stats_last_24h()
+
+
 COMMANDS = {
     "!mint": cmd_mint,
     "!codes": cmd_codes,
     "!revoke": cmd_revoke,
     "!retention-room": cmd_retention_room,
+    "!kick": cmd_kick,
+    "!ban": cmd_ban,
+    "!unban": cmd_unban,
+    "!stats": cmd_stats,
     "!help": None,  # filled below
 }
 


### PR DESCRIPTION
## What it does
Completes issue #7's Matrix admin surface with PL-gated `!kick`, `!ban`, `!unban`, and `!stats` commands. It also records the mautrix/E2EE admin-room decision and documents the co-admin handoff.

## What you get by merging
Human admins can revoke access, inspect recent onboarding activity, and manage invite codes from their own Matrix accounts without sharing the bot token or SSH access.

## Story
Issue: https://github.com/teleport-computer/shape-rotator-matrix/issues/7

Acceptance (issue #7 `## Acceptance`), and how each line now stands:
- `!mint` knock + signup codes, gated on PL — pre-existing on staging; re-proven by the standing gate's `admin_e2ee.py` (7/7) on this head; the PL gate itself proven live for the NEW commands (PL-0 user refused).
- `!codes` and `!revoke` — pre-existing on staging, not in this diff.
- `!ban` / `!kick` / `!unban` — **driven live, encrypted, 15/15**: bot replies + victim membership independently verified over the client-server API (`join → leave` kick, `→ ban` ban, `→ leave` unban); usage + self-kick guards proven.
- `!stats` with last-24h counts, pending flows, top captcha keywords — driven live twice (before/after moderation traffic); keyword line shown in its empty state on a fresh stack.
- E2EE decision recorded; `deploy/admin/README.md` co-admin handoff — doc additions in this diff.

## Evidence (Tier 1 — Matrix client-server API; this repo serves no `/_api/version`)
Changed files are `knock-approver/approver.py` + docs: the approver is a mautrix-python **client** serving no HTTP routes, and this repo has no `/_api/version` endpoint (`grep -rniE '_api/version'` → empty — same finding as merged #67/#88). The generic version-pin anchor is therefore substituted, exactly as the gate accepted for #88, by a **live read-only call against the deployed staging homeserver**; the behavior itself is demonstrated end-to-end over the Matrix client-server HTTP API, encrypted, against a real homeserver running this branch's code.

Committed to `.evidence/issue-7/` on this branch:
- `flow.md` — tier reasoning, acceptance asserted line by line, repro.
- `moderation_e2ee_transcript.txt` — **the new commands, driven live (15/15 pass)**: three fresh users (PL-50 admin `A`, PL-0 `N`, victim `V`), each sender a real mautrix client with OlmMachine + PgCryptoStore; commands sent **encrypted** into the encrypted admin command room; bot replies decrypted and asserted; membership verified independently via `GET …/state/m.room.member/{V}` (`join → leave → ban → leave`). Includes the knock-approver container's own `[admin] dispatch … is_admin=…` log lines. Key excerpts:
  - PL gate: `@mod_pleb…: refused — need PL >= 50 or be on the allowlist` (bot log: `is_admin=False`)
  - `!kick @mod_victim…` → `kicked @mod_victim… from the space`; API-verified `membership=leave`
  - `!ban @mod_victim…` → `banned … from the space`; API-verified `membership=ban`
  - `!unban @mod_victim…` → `unbanned … from the space`; API-verified `membership=leave`
  - `!stats` → `last 24h: knocks=0, promoted=0, rejected=0, pending=0` + `top captcha keywords: none` (twice)
- `drive_admin_moderation.py` — the reproducible driver itself.
- `e2e_gate_transcript.txt` — standing gate `bash tests/run_e2e.sh` on head `e1f6c23`: **all gating tests passed** (incl. `admin_e2ee.py` 7/7, `retention_room_e2e.py` 21/21).
- `staging_anchor.txt` — live read-only vs deployed staging: `GET /_matrix/client/versions` → HTTP 200; space alias `#shape-rotator:mtrx.shaperotator.xyz` resolves to `!4FL8uL5OEYLATG1VH4wC2CD3pfIV6BMFId9VT7rmm-g` — the same room ID recorded in merged #88's evidence, i.e. the exact room the new `rooms/{space}/(kick|ban|unban)` calls act on when deployed.

## Risk / what to watch
Moderation endpoints target only the configured Shape Rotator space. `!stats` reads the append-only audit log and current vetting/lobby state; malformed log lines are ignored. Honest limit: `!stats`'s keyword aggregation was shown live only in the empty state (fresh stack); aggregation over populated events is covered by the PR's focused handler checks, not by a live populated drive.

## What I could NOT verify
- No Matrix real-browser rig on this box → no screenshots of a human's Matrix client; the encrypted command round-trips above are the same wire behavior a client renders.
- The deployed staging approver runs merged staging code only, so unmerged commands cannot be driven against the deployment itself pre-merge; the read-only anchor pins the deployed environment instead.
- `!kick` of a user *present in the space* was proven; kick of a never-joined user (server 403 path) is exercised only by the handler's error branch, not live.

<details>
<summary>Diff stats</summary>

Code: `3 files changed, 130 insertions(+)` (e1f6c23)
Evidence: `.evidence/issue-7/` — 5 files (driver + 3 transcripts + flow.md), added in aba2e22

</details>