### PR TITLE
bridge: retry failed Matrix deliveries (#49)

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -46,11 +46,12 @@ and the relay's OWN `/sync` cursor lives at
 Absent on first start &rarr; advance to "now" without relaying (skip backlog,
 like the Telegram side).
 
-State is written atomically (tmp + rename) after every relay, so a kill between
-messages never double-delivers; on restart the relay catches up everything
-missed during downtime. The Matrix `/sync` cursor itself lives at
-`~/.shape-bridge-bot/store/next_batch` (`mx.py`'s `_FileSyncStore`); the relay
-owns it while it runs.
+State is written atomically (tmp + rename) after every successful relay, so a
+kill between messages never double-delivers; failed deliveries remain
+retryable. On restart the relay catches up everything missed during downtime.
+The relay's Matrix `/sync` cursor is the separate
+`~/.shape-bridge-bot/store/relay_next_batch` file described above; `mx.py`'s
+debug cursor is independent.
 
 `relay.py` imports the proven client machinery from `mx.py` (`make_client`,
 `load_config`, `_shutdown`) and `tg.py` (`make_client`, `load_chat_id`,

--- a/bridge/relay.py
+++ b/bridge/relay.py
@@ -309,7 +309,7 @@ async def mx_relay_once(mx_client, room, bot_mxid, tg_client, tg_chat_id, state,
         if evt.type != EventType.ROOM_MESSAGE:
             state.mark_mx(event_id)
             continue
-        if state.mark_mx(event_id):
+        if event_id in state.mx_seen:
             continue  # already relayed (dedup)
         body = _mx_body(evt)
         if body is None:
@@ -319,8 +319,10 @@ async def mx_relay_once(mx_client, room, bot_mxid, tg_client, tg_chat_id, state,
             await tg_send_relay(tg_client, tg_chat_id, name, body)
         except Exception as exc:
             log("tg", f"send failed for {event_id}: {type(exc).__name__}: {exc}")
-            # Don't advance past this event on failure — next pass retries.
+            # Do not mark the event until delivery succeeds. The next pass
+            # must retry a failed send, including after a process restart.
             continue
+        state.mark_mx(event_id)
         state.save()
     state.save()
 


### PR DESCRIPTION
## What it does
Fixes the Matrix→Telegram relay cursor so an event is added to the durable dedup set only after Telegram delivery succeeds. Corrects the bridge README to document the retry-safe behavior and the relay-owned Matrix sync cursor.

## What you get by merging
A transient Telegram/API failure no longer loses a Matrix message permanently; the next pass or restart retries it.

## Story
Part of [#49](https://github.com/teleport-computer/shape-rotator-matrix/issues/49).

Acceptance:
- Message posted in Telegram appears in the Matrix room within ~10s with sender name, and vice versa
- Kill the relay for a minute, restart: missed messages arrive once, no duplicates
- README section: how to run it, where state lives, how to add a room pair

## Evidence (Tier 1)
Live fixture acceptance against the provisioned Matrix room and Telegram test group:

- `python3 -m py_compile bridge/relay.py bridge/mx.py bridge/tg.py` — passed
- `bash -n bridge/acceptance.sh` — passed
- `bash bridge/acceptance.sh` — passed, 6/6 assertions
- TG→MX relay handling: 5s, cursor advanced, no own-echo leak
- MX→TG relay handling: 3s, event marked seen, no own-echo leak
- Restart #1 caught up both queued messages
- Restart #2 reprocessed neither; cursors remained stable

The full acceptance transcript is available from the worker run at `.acceptance-logs/full.log` (generated locally and ignored; no credentials or session files were committed).

## Risk / what to watch
The change only affects failure handling for Matrix→Telegram delivery and documentation. A failed Telegram send remains retryable; successful sends retain exactly-once dedup behavior.

## What I could NOT verify
This repository has no deployed relay service or `/_api/version` endpoint to pin to this PR commit. The live gate exercises the provisioned Matrix/Telegram fixture pair directly; deployment of a persistent relay is an operator-owned configuration step.

<details>
<summary>Diff stats and checks</summary>

- 2 files changed, 10 insertions, 7 deletions
- `git diff --check` — passed
</details>
