### PR TITLE
escrow durability: megolm inbound sessions survive self-heal wipe (#60)

### DIFF
--- a/.evidence/issue-60/escrow_durability.txt
+++ b/.evidence/issue-60/escrow_durability.txt
@@ -1,25 +1,15 @@
-[escrow] bot=@esc_bot_1783803920_6754:localhost:46167 (devs BOT_A_e403 -> BOT_B_4d28) alice=@esc_alice_1783803920_6754:localhost:46167
-[escrow] room=!toJ2t5qrm45GcAbu03uelexOmthA7YNVXqsb0w3W2zI
-Device @esc_alice_1783803920_6754:localhost:46167/ALICE3a97 isn't cross-signed
-Device @esc_bot_1783803920_6754:localhost:46167/BOT_A_e403 isn't cross-signed
-Device @esc_bot_1783803920_6754:localhost:46167/BOT_A_e403 isn't cross-signed
-Didn't find cross-signing key master of @esc_bot_1783803920_6754:localhost:46167
-[escrow] pre-wipe msg id=$hMYFDJRq_BMrysrz4eFqr2DVnHN9D6AcovQA8e2SMk8 body='history-must-survive-03167c4d'
-Device @esc_alice_1783803920_6754:localhost:46167/ALICE3a97 isn't cross-signed
-Device @esc_alice_1783803920_6754:localhost:46167/ALICE3a97 isn't cross-signed
-Didn't find cross-signing key master of @esc_alice_1783803920_6754:localhost:46167
+[escrow] bot=@esc_bot_1785264625_c48e:localhost:46167 (devs BOT_A_d459 -> BOT_B_2e28) alice=@esc_alice_1785264625_c48e:localhost:46167
+[escrow] room=!L2nqyCKHX7E4pKP08t95zI2bbcg981Zc3t5ZK2MePuI
+[escrow] pre-wipe msg id=$pY9F0kGt0NEpaFQ6t2HX5TvQHYitwqIT3LyirJsSLEE body='history-must-survive-060d6d0a'
   [PASS] bot device A decrypts the message (inbound session present)
   [PASS] export_inbound_sessions dumps the inbound megolm session(s)  (1 session(s) -> inbound_sessions.escrow.json)
-[self-heal] removed /tmp/escrow_1783803920_6754/bot_crypto.db
+[self-heal] removed /tmp/escrow_1785264625_c48e/bot_crypto.db
   [PASS] _wipe_crypto_store deletes bot_crypto.db  (fresh store on next open)
   [PASS] without escrow, wiped store cannot decrypt (the bug #60 fixes)  (SessionNotFound after wipe)
-[self-heal] removed /tmp/escrow_1783803920_6754/bot_crypto.db
-  [PASS] re-mint logs the bot in under a NEW device_id  (BOT_A_e403 -> BOT_B_4d28)
+[self-heal] removed /tmp/escrow_1785264625_c48e/bot_crypto.db
+  [PASS] re-mint logs the bot in under a NEW device_id  (BOT_A_d459 -> BOT_B_2e28)
   [PASS] import_inbound_sessions restores the escrowed session(s)  (1/1 restored)
-Device @esc_alice_1783803920_6754:localhost:46167/ALICE3a97 isn't cross-signed
-Device @esc_alice_1783803920_6754:localhost:46167/ALICE3a97 isn't cross-signed
-Didn't find cross-signing key master of @esc_alice_1783803920_6754:localhost:46167
-  [PASS] re-minted bot (new device) decrypts the pre-wipe message  (body='history-must-survive-03167c4d')
+  [PASS] re-minted bot (new device) decrypts the pre-wipe message  (body='history-must-survive-060d6d0a')
   [PASS] escrow file is retained after import (durable across wipes)
 
 [escrow] 8/8 checks passed

--- a/.evidence/issue-60/escrow_durability.txt
+++ b/.evidence/issue-60/escrow_durability.txt
@@ -1,15 +1,25 @@
-[escrow] bot=@esc_bot_1785264625_c48e:localhost:46167 (devs BOT_A_d459 -> BOT_B_2e28) alice=@esc_alice_1785264625_c48e:localhost:46167
-[escrow] room=!L2nqyCKHX7E4pKP08t95zI2bbcg981Zc3t5ZK2MePuI
-[escrow] pre-wipe msg id=$pY9F0kGt0NEpaFQ6t2HX5TvQHYitwqIT3LyirJsSLEE body='history-must-survive-060d6d0a'
+[escrow] bot=@esc_bot_1787011017_e53e:localhost:46167 (devs BOT_A_3b96 -> BOT_B_d022) alice=@esc_alice_1787011017_e53e:localhost:46167
+[escrow] room=!_ScwVejN2UmmKdVCfHdq5L0m2Evbu843AbZIUPMJeRU
+Device @esc_alice_1787011017_e53e:localhost:46167/ALICEf12e isn't cross-signed
+Device @esc_bot_1787011017_e53e:localhost:46167/BOT_A_3b96 isn't cross-signed
+Device @esc_bot_1787011017_e53e:localhost:46167/BOT_A_3b96 isn't cross-signed
+Didn't find cross-signing key master of @esc_bot_1787011017_e53e:localhost:46167
+[escrow] pre-wipe msg id=$36tzV8LDqSW58qp4_Z9xGkr5yLkX6IW0h6R9LLMHUPo body='history-must-survive-beb7056c'
+Device @esc_alice_1787011017_e53e:localhost:46167/ALICEf12e isn't cross-signed
+Device @esc_alice_1787011017_e53e:localhost:46167/ALICEf12e isn't cross-signed
+Didn't find cross-signing key master of @esc_alice_1787011017_e53e:localhost:46167
   [PASS] bot device A decrypts the message (inbound session present)
   [PASS] export_inbound_sessions dumps the inbound megolm session(s)  (1 session(s) -> inbound_sessions.escrow.json)
-[self-heal] removed /tmp/escrow_1785264625_c48e/bot_crypto.db
+[self-heal] removed /tmp/escrow_1787011017_e53e/bot_crypto.db
   [PASS] _wipe_crypto_store deletes bot_crypto.db  (fresh store on next open)
   [PASS] without escrow, wiped store cannot decrypt (the bug #60 fixes)  (SessionNotFound after wipe)
-[self-heal] removed /tmp/escrow_1785264625_c48e/bot_crypto.db
-  [PASS] re-mint logs the bot in under a NEW device_id  (BOT_A_d459 -> BOT_B_2e28)
+[self-heal] removed /tmp/escrow_1787011017_e53e/bot_crypto.db
+  [PASS] re-mint logs the bot in under a NEW device_id  (BOT_A_3b96 -> BOT_B_d022)
   [PASS] import_inbound_sessions restores the escrowed session(s)  (1/1 restored)
-  [PASS] re-minted bot (new device) decrypts the pre-wipe message  (body='history-must-survive-060d6d0a')
+Device @esc_alice_1787011017_e53e:localhost:46167/ALICEf12e isn't cross-signed
+Device @esc_alice_1787011017_e53e:localhost:46167/ALICEf12e isn't cross-signed
+Didn't find cross-signing key master of @esc_alice_1787011017_e53e:localhost:46167
+  [PASS] re-minted bot (new device) decrypts the pre-wipe message  (body='history-must-survive-beb7056c')
   [PASS] escrow file is retained after import (durable across wipes)
 
 [escrow] 8/8 checks passed

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,32 @@
-# Issue #20 plan
+# PLAN — issue #60: escrow durability (megolm inbound sessions survive self-heal wipe)
 
-- [x] Require admin commands to arrive as decrypted Matrix events.
-- [x] Require mautrix `CROSS_SIGNED_TOFU` (or stronger) before PL/allowlist authorization.
-- [x] Refuse unknown, unverified, and rotated-device commands and audit the refusal.
-- [x] Document the threat model and the remaining hermes-agent scope.
-- [ ] Verify the deployed staging knock-approver flow with a signed-in operator device.
-- [ ] Apply the equivalent sender verification to the hermes shape-rotator agent (separate repo).
+Branch: `ready-60` (base `staging`). Tier 1 (backend/self-heal; no UI surface).
+
+## Acceptance (from issue #60)
+A test in `tests/` (dev stack, style of `history_e2ee_repro.py`) showing:
+bot client receives an encrypted message → simulate re-mint (run the ACTUAL
+export/wipe/import functions with a NEW device_id + fresh store, not a
+hand-rolled imitation) → bot still decrypts the old message. Test run output
+in the PR. Tier 1: test transcript is the evidence.
+
+## Tasks
+- [x] Read MATRIX_ONBOARDING.md (required), self_heal_unit.py, PR #59 primitive.
+- [x] Confirm mautrix API: `export_session(idx)->str`, `import_session(session_key,...)`,
+      `put_group_session`, enumerate via SQL on `crypto_megolm_inbound_session`.
+- [x] **approver.py**: add `ESCROW_PATH`, `export_inbound_sessions(cs)`,
+      `import_inbound_sessions(cs)` (raises on per-session failure, no skip),
+      `_export_escrow_for_wipe(mxid, old_device_id)` helper.
+- [x] **approver.py main()**: export BEFORE `_wipe_crypto_store()`.
+- [x] **approver.py sync_loop()**: import AFTER fresh store opens.
+- [x] **tests/escrow_durability.py**: bot devA receives+decrypts → export → wipe →
+      fresh store w/ NEW device_id → import → old msg still decrypts. Uses the
+      ACTUAL approver functions + sas_e2e helpers.
+- [x] Run the test against the dev stack (continuwuity in docker; test in the
+      `tests/Dockerfile` runner, `--network host`). Capture transcript.
+- [x] Commit (incl. transcript), push, open PR to staging. Remove `ready` label.
+
+## Notes (issue constraints)
+- plaintext in /data is fine (same trust domain as bot_crypto.db).
+- imported sessions carry forwarding chain / lower trust — expected.
+- keep the escrow file after import (it IS the durable escrow; replaced next wipe).
+- import MUST raise, never silently skip (no fallbacks).

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -328,7 +328,10 @@ async def export_inbound_sessions(cs, dest=None):
     for row in rows:
         sess = await cs.get_group_session(row["room_id"], row["session_id"])
         if sess is None:
-            continue
+            raise RuntimeError(
+                "inbound megolm session disappeared during escrow export: "
+                f"room={row['room_id']} session={row['session_id']}"
+            )
         out.append({
             "room_id":          str(sess.room_id),
             "sender_key":       str(sess.sender_key),
@@ -2818,10 +2821,8 @@ async def main():
         # messages stay decryptable after re-mint (issue #60). Only the
         # device-rotated path has a known old pickle key to read from; the
         # transition case (no cached device_id) cannot be escrowed and those
-        # stale pickles were unreadable anyway. An export failure PROPAGATES
-        # and blocks the wipe — same loud-failure contract as the import side:
-        # we refuse to destroy the store's history on a failure we can't
-        # explain rather than boot looking healthy with history silently lost.
+        # stale pickles were unreadable anyway. Escrow failure propagates so
+        # the store is never wiped after an unsuccessful backup.
         if sr2_cached_device_before:
             _n = await _export_escrow_for_wipe(sr2_mxid, sr2_cached_device_before)
             print(f"[self-heal] escrowed {_n} inbound megolm sessions to "


### PR DESCRIPTION
## What it does
Issue #60's escrow export/wipe/import already shipped to staging via #64. After rebasing onto staging, this PR is the remaining delta: `export_inbound_sessions` raises when an inbound megolm session disappears mid-export (DB row present, `get_group_session` returns None) instead of silently `continue`-ing past it — issue #60's "must raise, not be skipped silently (no fallbacks)" applied to the export side. Staging's `main()` comment already claims "An export failure PROPAGATES and blocks the wipe"; this makes the code match that comment.

## What you get by merging
A failed or inconsistent escrow export blocks the self-heal crypto-store wipe instead of destroying history while booting looking healthy. The runtime error names the room and session.

## Story
[#60](https://github.com/teleport-computer/shape-rotator-matrix/issues/60)

Acceptance: A test in `tests/` (dev stack, style of `history_e2ee_repro.py`) showing: bot client receives an encrypted message → simulate re-mint (run the actual export/wipe/import functions with a NEW device_id + fresh store, not a hand-rolled imitation) → bot still decrypts the old message. Include the test run output in the PR. Tier 1: test transcript is the evidence; no user-visible surface.

## Evidence (Tier 0 — no user-visible or API-visible surface; floor met and exceeded)
**Tier 0 declaration:** the delta vs staging is one behavior change inside `knock-approver/approver.py` (`continue` → `raise RuntimeError` in `export_inbound_sessions`, plus a comment tightening in `main()`). It touches no HTTP handler, route, or UI — `git diff origin/staging...origin/ready-60 -- knock-approver/approver.py` contains hunks only in the internal crypto-store escrow path. Same surface classification #64 (the merged first half of issue #60) declared and the merge gate accepted for this exact function: internal crypto-store lifecycle, no request handler, no user surface.

- **Tier 0 floor (typecheck + tests green):** CI `e2e` suite passed on head `51ccebd` (run 32082620097 — "all tests passed" + full PASS battery against the dev stack).
- **Issue acceptance evidence (exceeds the floor):** `tests/escrow_durability.py` re-run on the rebased code against an isolated local Continuwuity dev stack (`DEV_STACK_SUFFIX=-rw73 DEV_HS_PORT=46273`). **8/8 checks passed** — pre-wipe decrypt, actual export, actual wipe, new-device re-mint (BOT_A_3b96 → BOT_B_d022), actual import, old-message decrypt after re-mint, escrow retention. Transcript: `.evidence/issue-60/escrow_durability.txt` (regenerated post-rebase at `51ccebd`).

## Risk / what to watch
- The only caller is the self-heal wipe path (`_export_escrow_for_wipe`), invoked before `_wipe_crypto_store`. A pre-existing store inconsistency that #64 silently skipped will now abort with a RuntimeError before the wipe — that is the intended loud-failure contract; the fix is to repair the escrow/store, not to restart.
- **`validate` is red for a repo-environmental reason, not this diff:** it fails at CVM provision with `HTTP: 401 Unauthorized — Invalid API key` (run 32082620039), before any PR code runs; the `PHALA_API_KEY` repo secret was last updated 2026-05-28 and equally fails other PRs' validate runs. Needed from the operator: refresh the secret, then re-run `validate`. Note the auto-merge gate does not inspect CI conclusions — it may merge while `validate` is red. If PR-time deploy validation should block merging, refresh the key or add branch protection to `staging`.

## What I could NOT verify
I verified the acceptance flow against the local dev stack. I did not deploy this branch to the remote staging service from this worker — the `validate` path that would do so is blocked on the stale `PHALA_API_KEY` above.

<details>
<summary>Diff stats (vs staging after rebase)</summary>

`3 files changed` — `knock-approver/approver.py` (+6/−5: `continue` → raise + comment), `PLAN.md` (this branch's issue-60 plan), `.evidence/issue-60/escrow_durability.txt` (regenerated transcript). CI `e2e` suite passed on 51ccebd.

</details>
