### PR TITLE
ci: validate KNOCK_APPROVER_TOKEN + PHALA_API_KEY before the 10-min sleep (#43)

### DIFF
--- a/.evidence/issue-43/01-both-bad.txt
+++ b/.evidence/issue-43/01-both-bad.txt
@@ -1,0 +1,5 @@
+::error::KNOCK_APPROVER_TOKEN is stale or invalid — whoami returned 401 (expected 200).
+::error::Rotate it: ssh the CVM, read the persisted bot token, then 'gh secret set KNOCK_APPROVER_TOKEN'.
+::error::PHALA_API_KEY is stale or invalid — 'phala cvms get dstack-matrix' rejected the key.
+::error::Rotate it at cloud.phala.com → API keys, then 'gh secret set PHALA_API_KEY'.
+::error::validate-creds: 2 check(s) failed — deploy aborted before the pre-deploy sleep.

--- a/.evidence/issue-43/02-indeterminate.txt
+++ b/.evidence/issue-43/02-indeterminate.txt
@@ -1,0 +1,5 @@
+::error::KNOCK_APPROVER_TOKEN could not be validated — whoami returned 500 (expected 200).
+::error::This is probably NOT a stale token: is mtrx.shaperotator.xyz reachable from the runner? Deploy aborted (fail-closed).
+::error::PHALA_API_KEY is stale or invalid — 'phala cvms get dstack-matrix' rejected the key.
+::error::Rotate it at cloud.phala.com → API keys, then 'gh secret set PHALA_API_KEY'.
+::error::validate-creds: 2 check(s) failed — deploy aborted before the pre-deploy sleep.

--- a/.evidence/issue-43/evidence.md
+++ b/.evidence/issue-43/evidence.md
@@ -1,0 +1,57 @@
+# Evidence — issue #43 (deploy.yml: validate creds before the 10-min sleep)
+
+**Tier 0** — CI/workflow-only change. Zero deployed-app behavior change (the issue
+confirms: "Tier 0 on the deployed app — no runtime behavior changes"). The only runtime
+effect is that the deploy job can now abort a few seconds earlier, before the 10-minute
+pre-deploy sleep, when a secret is stale.
+
+## What changed
+- `deploy/validate-creds.sh` (new) — checks `KNOCK_APPROVER_TOKEN` (via `whoami`) and
+  `PHALA_API_KEY` (via `phala cvms get dstack-matrix`). **Accumulates** failures and names
+  every bad secret in one run (the issue's proposed snippet `exit 1`s on the first failure,
+  which would NOT satisfy "two stale secrets cost one cycle, not two"). Distinguishes a
+  definitive auth failure (whoami 401/403; phala "Invalid API key") from an indeterminate
+  one (timeout / 5xx) so a homeserver hiccup is not mislabeled a stale token. Prints no
+  secret values.
+- `.github/workflows/deploy.yml` — one new step `validate creds (fail fast on stale
+  secrets)`, placed after `install phala CLI` (needs the binary) and before `build .env` /
+  the 10-minute `pre-deploy heads-up + delay` sleep.
+
+## Local verification (this box, real endpoints)
+Run with deliberately-wrong, non-secret test values (no real secrets used).
+
+### 01-both-bad.txt — BOTH stale (definitive auth failures)
+- `KNOCK_APPROVER_TOKEN` = bogus → whoami **401**
+- `PHALA_API_KEY` = bogus → `phala cvms get` exits 1, stderr `✗ Invalid API key`
+- Result: names **KNOCK** stale AND **PHALA** stale in ONE run; exit **1**; **~1.6s**
+  (≪ 30s, and before the 10-min sleep by step placement); **no secret value** printed.
+- This is the acceptance's core case: "two stale secrets cost one cycle, not two."
+
+### 02-indeterminate.txt — homeserver 500 (NOT a stale token) + bad phala key
+- whoami returns **500** (mocked local server) → reported honestly as
+  "could not be validated — probably NOT a stale token" (NOT mislabeled stale); deploy
+  still aborts (fail-closed).
+- phala bad key → reported stale.
+- Demonstrates the no-masking rule: a network/server error is not blamed on the secret.
+
+### phala stderr-capture idiom (branch logic)
+`phala_err=$(phala cvms get … 2>&1 >/dev/null)` captures rc=1 and stderr containing
+`Invalid API key`; the `grep -qi 'invalid api key'` match routes it to the "stale" branch.
+
+## What I could NOT verify on this box (operator-run; see issue comment)
+The issue requests "a link to a workflow run with a deliberately-wrong secret + a passing
+run." That evidence is inherently **post-merge / operator-gated**:
+- The deploy workflow only fires on `v*` tag push or `workflow_dispatch`, and then performs
+  a **real production deploy** of the `dstack-matrix` CVM. No prod credentials exist on this
+  box (box-inventory), and workers must not trigger production deploys.
+- The new step cannot run inside the workflow until the branch is merged and a tag is pushed.
+- Producing the "wrong secret" variant requires the operator to write a deliberately-bad GH
+  secret (a repo-secret write, not available to the worker).
+
+So the pre-merge Tier-0 evidence above is the strongest verification possible from this box;
+the real-workflow-run evidence is left as the explicit operator step in the issue comment.
+
+## The "all good → creds validated" branch
+Not exercised locally (would require the real `PHALA_API_KEY`, a repo secret). Logic is
+trivial: both checks pass → `failures` stays 0 → prints `creds validated` → exit 0. The
+deploy workflow itself exercises this on every successful tag deploy once merged.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,17 @@ jobs:
       - name: install phala CLI
         run: npm install -g phala
 
+      - name: validate creds (fail fast on stale secrets)
+        # Runs BEFORE build .env and the 10-min pre-deploy sleep so a stale
+        # KNOCK_APPROVER_TOKEN or PHALA_API_KEY aborts the deploy in seconds,
+        # naming which secret(s) are bad. Checks BOTH in one run so two stale
+        # secrets cost one cycle to discover, not two (see issue #43). Prints
+        # no secret values. See deploy/validate-creds.sh.
+        env:
+          KNOCK_APPROVER_TOKEN: ${{ secrets.KNOCK_APPROVER_TOKEN }}
+          PHALA_API_KEY: ${{ secrets.PHALA_API_KEY }}
+        run: bash deploy/validate-creds.sh
+
       - name: build .env
         env:
           NAMECHEAP_USERNAME: ${{ secrets.NAMECHEAP_USERNAME }}

--- a/deploy/admin/mint_token.sh
+++ b/deploy/admin/mint_token.sh
@@ -14,6 +14,17 @@
 #   4. Update GitHub secret KNOCK_APPROVER_TOKEN (token never echoed)
 #   5. Re-enable the deploy workflow if disabled
 #   6. Trigger a deploy run
+#
+# Spec impact — deploy validation (added 2026-08-05, PR #75 / issue #43):
+# This script rotates ONLY KNOCK_APPROVER_TOKEN. The deploy workflow now runs
+# `deploy/validate-creds.sh` as its first step, checking BOTH
+# KNOCK_APPROVER_TOKEN (whoami) and PHALA_API_KEY (phala cvms get dstack-matrix)
+# BEFORE the 10-minute pre-deploy sleep. Consequence for this runbook: if
+# PHALA_API_KEY is *also* stale (it was the cycle-2 failure in #43, which this
+# script does not touch), the deploy triggered in step 6 now fails fast (~2s,
+# named) instead of burning a full ~17-min cycle. To clear it, rotate at
+# cloud.phala.com → API keys, then:
+#   gh secret set PHALA_API_KEY --repo "$(git config --get remote.origin.url)"
 set -euo pipefail
 
 HS=https://mtrx.shaperotator.xyz

--- a/deploy/validate-creds.sh
+++ b/deploy/validate-creds.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fail fast — BEFORE the deploy job's 10-minute pre-deploy sleep — if either
+# KNOCK_APPROVER_TOKEN or PHALA_API_KEY is stale or invalid.
+#
+# Why this exists: the v0.7.03 redeploy burned two ~17-min cycles discovering two
+# stale GH secrets serially (KNOCK in the heads-up step, then PHALA in phala deploy).
+# This step runs both checks up front, in ONE run, and names EVERY bad secret so two
+# stale secrets cost one cycle to discover — not two. See issue #43.
+#
+# Never prints secret values: only HTTP status codes and pass/fail lines.
+#
+# Fail-closed: if a check is indeterminate (e.g. the homeserver or Phala Cloud is
+# unreachable), the deploy still aborts — but the message says "could not validate"
+# rather than falsely claiming the secret is stale, so the operator isn't misled into
+# rotating a good token. A definitive auth failure (401/403 or a rejected API key) is
+# reported as stale.
+#
+# Required env (set by the workflow step from GitHub secrets):
+#   KNOCK_APPROVER_TOKEN  access token of @shape-rotator-2 (must whoami 200)
+#   PHALA_API_KEY         phala CLI api token (must be able to read dstack-matrix)
+set -uo pipefail
+
+failures=0
+
+# 1. KNOCK_APPROVER_TOKEN must authenticate as a valid account.
+#    200 = good; 401/403 = stale/invalid; anything else (000 timeout, 5xx, ...) =
+#    indeterminate — fail closed but don't claim the token is stale.
+whoami_code=$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer ${KNOCK_APPROVER_TOKEN:-}" \
+  https://mtrx.shaperotator.xyz/_matrix/client/v3/account/whoami || true)
+case "$whoami_code" in
+  200)
+    echo "KNOCK_APPROVER_TOKEN: whoami 200 OK"
+    ;;
+  401|403)
+    echo "::error::KNOCK_APPROVER_TOKEN is stale or invalid — whoami returned ${whoami_code} (expected 200)."
+    echo "::error::Rotate it: ssh the CVM, read the persisted bot token, then 'gh secret set KNOCK_APPROVER_TOKEN'."
+    failures=$((failures + 1))
+    ;;
+  *)
+    echo "::error::KNOCK_APPROVER_TOKEN could not be validated — whoami returned ${whoami_code} (expected 200)."
+    echo "::error::This is probably NOT a stale token: is mtrx.shaperotator.xyz reachable from the runner? Deploy aborted (fail-closed)."
+    failures=$((failures + 1))
+    ;;
+esac
+
+# 2. PHALA_API_KEY must be able to read the target CVM.
+#    phala exits nonzero on a rejected key ("Invalid API key"), but also on a
+#    renamed/removed CVM or a Phala Cloud outage — capture stderr to distinguish.
+# No `set -e`, so a failing phala won't abort; capture its real rc + stderr.
+# `2>&1 >/dev/null` inside $() captures STDERR (discards stdout) into phala_err.
+phala_err=$(phala cvms get dstack-matrix --api-token "${PHALA_API_KEY:-}" 2>&1 >/dev/null)
+phala_rc=$?
+if [ "$phala_rc" -eq 0 ]; then
+  echo "PHALA_API_KEY: can read dstack-matrix"
+else
+  if printf '%s' "$phala_err" | grep -qi 'invalid api key'; then
+    echo "::error::PHALA_API_KEY is stale or invalid — 'phala cvms get dstack-matrix' rejected the key."
+    echo "::error::Rotate it at cloud.phala.com → API keys, then 'gh secret set PHALA_API_KEY'."
+  else
+    echo "::error::PHALA_API_KEY could not be validated — 'phala cvms get dstack-matrix' failed (rc=${phala_rc})."
+    echo "::error::This may not be a stale key (CVM renamed/removed, or Phala Cloud unreachable): ${phala_err}. Deploy aborted (fail-closed)."
+  fi
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "::error::validate-creds: ${failures} check(s) failed — deploy aborted before the pre-deploy sleep."
+  exit 1
+fi
+
+echo "creds validated"


### PR DESCRIPTION
## What it does
Adds a `validate creds` step to the `deploy` workflow (and a `deploy/validate-creds.sh` helper) that checks `KNOCK_APPROVER_TOKEN` (via Matrix `whoami`) and `PHALA_API_KEY` (via `phala cvms get dstack-matrix`) **before** the 10-minute pre-deploy sleep, so a stale secret aborts the deploy in ~2s instead of burning a full ~17-min cycle.

## What you get by merging
The exact failure mode from the v0.7.03 redeploy (two stale GH secrets discovered serially, ~34 min lost) becomes one fast, named failure. Both secrets are checked in a single run, so two stale secrets cost **one** cycle to discover, not two. The Actions log names exactly which secret(s) are bad and how to rotate them.

## Story
Closes #43. Restating its `## Acceptance`:
- A stale `KNOCK_APPROVER_TOKEN` or `PHALA_API_KEY` fails the deploy in under ~30s, before the 10-minute sleep, naming WHICH secret is bad.
- Both are checked in the same run, so two stale secrets cost one cycle to discover, not two.
- The check runs first (a `validate creds` step at the top of the job). Must not print secret values.

## Deviation from the issue's proposed snippet (correctness)
The snippet in the issue does `exit 1` after the **first** failing check, so if both secrets are stale only the first is reported and the job re-runs to find the second — that is precisely the serial rediscovery the acceptance forbids. This implementation **accumulates** failures and names every bad secret in one run. It also distinguishes a definitive auth failure (`whoami` 401/403; phala `Invalid API key`) from an indeterminate one (timeout/5xx) so a homeserver hiccup is not mislabeled a stale token — the deploy still aborts (fail-closed), but the message is honest. Prints no secret values (only HTTP codes + pass/fail).

## Evidence (Tier 0)
Tier 0: CI/workflow-only change; **zero deployed-app behavior change** (the issue confirms: "Tier 0 on the deployed app — no runtime behavior changes"). The only runtime effect is that the deploy job can abort a few seconds earlier.

Verification on this box against the real `mtrx.shaperotator.xyz` whoami endpoint and the real `phala` CLI (deliberately-wrong, non-secret test values — no real secrets used):

**Both stale (definitive auth failures)** — `.evidence/issue-43/01-both-bad.txt`, ran in **~1.6s**, exit 1:
```
::error::KNOCK_APPROVER_TOKEN is stale or invalid — whoami returned 401 (expected 200).
::error::PHALA_API_KEY is stale or invalid — 'phala cvms get dstack-matrix' rejected the key.
::error::validate-creds: 2 check(s) failed — deploy aborted before the pre-deploy sleep.
```
Both secrets named in ONE run (the acceptance's core "one cycle, not two" case). No secret value printed.

**Indeterminate (homeserver 500, not a stale token) + bad phala key** — `.evidence/issue-43/02-indeterminate.txt`:
```
::error::KNOCK_APPROVER_TOKEN could not be validated — whoami returned 500 (expected 200).
::error::This is probably NOT a stale token: is mtrx.shaperotator.xyz reachable from the runner? ...
::error::PHALA_API_KEY is stale or invalid — 'phala cvms get dstack-matrix' rejected the key.
```
Shows the no-masking rule: a server/network error is not blamed on the secret.

Step placement (deploy job): `checkout` → `setup-node` → `install phala CLI` → **`validate creds`** → `build .env` → `pre-deploy heads-up + delay` (the 10-min sleep) → `phala deploy` → … — i.e. after phala is installed, before the sleep. YAML validated with PyYAML; script `bash -n` clean.

## What I could NOT verify (operator-run; see issue comment)
The issue asks for "a link to a workflow run with a deliberately-wrong secret + a passing run." That evidence is inherently post-merge / operator-gated:
- The deploy workflow only fires on `v*` tag push or `workflow_dispatch` and then performs a **real production deploy** of `dstack-matrix`. No prod credentials exist on this box and workers must not trigger production deploys.
- The new step cannot run inside the workflow until the branch is merged and a tag is pushed.
- The "wrong secret" variant needs the operator to write a deliberately-bad GH secret (repo-secret write, unavailable to the worker).

The "all-good → `creds validated`" branch wasn't exercised locally (would need the real `PHALA_API_KEY`, a repo secret); its logic is trivial (both checks pass → exit 0) and is exercised by every successful tag deploy once merged.

## Spec impact
Amended the doc that permitted the defect: **`deploy/admin/mint_token.sh`** is the operator runbook for rotating `KNOCK_APPROVER_TOKEN` and (step 6) triggering a deploy. Its step-6 flow + closing "Watch the deploy" hint codified the *deploy-without-fast-credential-check* behavior that let the #43 symptom burn ~34 min across two cycles — and it rotates ONLY `KNOCK_APPROVER_TOKEN` (not `PHALA_API_KEY`, which was the cycle-2 failure). A dated entry (2026-08-05, PR #75, commit af2223c) is appended to that runbook's header so a future operator following it knows the triggered deploy now fast-fails (~2s, named) on a stale `PHALA_API_KEY`, and how to rotate it. Comment-only change; `bash -n` clean.

## Risk / what to watch
- Fails **closed**: a transient whoami 5xx/timeout now aborts the deploy (previously it would have failed a few steps later at the heads-up/health-check anyway). The message distinguishes this from a stale token so you won't rotate a good secret by mistake.
- If `dstack-matrix` is ever renamed, the phala check fails — update the CVM name in `deploy/validate-creds.sh` (and in the existing `phala deploy` step).
- `phala cvms get` exiting nonzero-on-bad-key is current CLI behavior; if a future phala version changes its exit code on auth failure, the indeterminate branch still fails-closed (just with the less-specific message).

<details>
<summary>diff stats</summary>

```
 .github/workflows/deploy.yml     | 11 +++++++++++
 deploy/validate-creds.sh         | 75 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .evidence/issue-43/01-both-bad.txt   |  5 +++++
 .evidence/issue-43/02-indeterminate.txt |  5 +++++
 .evidence/issue-43/evidence.md       | 57 +++++++++++++++++++++++++++++++++++++++++++++
```
</details>

