### PR TITLE
dev/tests: isolate concurrent stacks so parallel agent lanes don't collide

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -69,3 +69,30 @@ HOMESERVER=http://localhost:46167 \
 - **Port choice**: we use `46167` (rather than the tutorial-default `16167`)
   because other throwaway repro containers in the workspace tend to grab the
   lower ports.
+
+## Running two dev stacks at once
+
+Parallel agent lanes on one box need separate compose projects and separate
+host ports, or `docker compose down -v` in one lane wipes the other's rocksdb:
+
+```bash
+# lane A — defaults, exactly as before
+docker compose up -d
+python3 bootstrap.py
+
+# lane B — concurrent, fully isolated
+DEV_STACK_SUFFIX=-b DEV_HS_PORT=46168 docker compose up -d
+DEV_HS=http://localhost:46168 python3 bootstrap.py
+```
+
+`DEV_STACK_SUFFIX` scopes the compose project name and its named volume;
+`DEV_HS_PORT` moves the published port. Neither is required — with both unset
+this behaves as it always has.
+
+`CONDUWUIT_SERVER_NAME` stays `localhost:46167` in every lane on purpose. It is
+the server's identity (it appears in mxids and in `bootstrap.py`'s `via`
+entries), not an endpoint anyone dials, and federation is off in dev.
+
+`tests/run_e2e.sh` derives its own compose project from the checkout path, so
+two worktrees running the e2e suite concurrently do not collide. Override with
+`E2E_PROJECT` if you need a specific name.

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -12,12 +12,24 @@
 #
 # Teardown:
 #   docker compose down -v           # -v drops the rocksdb volume for a clean slate
+#
+# Running two dev stacks at once (parallel agent lanes on one box):
+#   DEV_STACK_SUFFIX=-a DEV_HS_PORT=46168 docker compose up -d
+#   DEV_HS=http://localhost:46168 python3 bootstrap.py
+# The suffix scopes the compose project *and* its named volume, so a
+# `docker compose down -v` in one lane cannot wipe another lane's rocksdb.
+# Without either var this behaves exactly as it always has.
+name: shape-rotator-dev${DEV_STACK_SUFFIX:-}
 services:
   continuwuity:
     image: ghcr.io/continuwuity/continuwuity:latest
     ports:
-      - "127.0.0.1:46167:6167"
+      - "127.0.0.1:${DEV_HS_PORT:-46167}:6167"
     environment:
+      # Deliberately NOT tied to DEV_HS_PORT. This is the server's identity —
+      # it appears in every mxid and in bootstrap.py's `via` entries — not an
+      # endpoint anyone dials. Federation is off, so it never has to resolve,
+      # and holding it constant keeps mxids stable across lanes.
       CONDUWUIT_SERVER_NAME: "localhost:46167"
       CONDUWUIT_DATABASE_BACKEND: rocksdb
       CONDUWUIT_DATABASE_PATH: /var/lib/conduwuit

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -14,7 +14,14 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-COMPOSE=(docker compose -f docker-compose.test.yml -p shape-rotator-e2e)
+# Project name is derived from the checkout path so two worktrees on the same
+# box get separate compose projects (and therefore separate named volumes).
+# Without this, the `down -v --remove-orphans` below tears down whichever run
+# got there first — the two lanes silently destroy each other. Same checkout
+# run twice still reuses one project, which is what the teardown expects.
+E2E_PROJECT="${E2E_PROJECT:-shape-rotator-e2e-$(git rev-parse --show-toplevel | cksum | cut -d' ' -f1)}"
+echo "[run_e2e] compose project: $E2E_PROJECT" >&2
+COMPOSE=(docker compose -f docker-compose.test.yml -p "$E2E_PROJECT")
 
 cleanup() {
   rc=$?


### PR DESCRIPTION
## Problem

Two chips worked on the same box destroyed each other, which is why the matrix lane has only ever run agents sequentially (`matrix-ready-chip` then `matrix-ready-chip-rework`).

- `dev/docker-compose.yml` published a fixed `127.0.0.1:46167` and took its compose project name from the directory basename (`dev`). A second lane failed to bind the port, and — worse — `docker compose down -v` in either lane removed the other's rocksdb volume.
- `tests/run_e2e.sh` had the same problem via a hardcoded `-p shape-rotator-e2e`. Its very first action is `down -v --remove-orphans`, so a second concurrent run silently tore down the first.

Worth noting the e2e stack itself was never the problem — `docker-compose.test.yml` publishes no host ports at all. It was purely the shared project name.

## Change

- **dev:** `name: shape-rotator-dev${DEV_STACK_SUFFIX:-}` scopes the project and its named volume; `${DEV_HS_PORT:-46167}` moves the published port. Both unset = previous behavior.
- **tests:** compose project derived from the checkout path, so two worktrees get separate projects and volumes. `E2E_PROJECT` overrides.
- **docs:** `dev/README.md` gets the two-lane recipe.

`CONDUWUIT_SERVER_NAME` stays `localhost:46167` in every lane deliberately — it is the server identity baked into mxids and `bootstrap.py`'s `via` entries, not an endpoint anyone dials, and federation is off in dev. Holding it constant keeps mxids stable across lanes.

## Verification

Ran on the laptop, both lanes concurrently:

```
:46167 -> 200        :46168 -> 200
shape-rotator-dev_continuwuity-dev-data
shape-rotator-dev-b_continuwuity-dev-data

# down -v on lane B:
 Volume shape-rotator-dev-b_continuwuity-dev-data Removed
# lane A afterwards:
:46167 -> 200        shape-rotator-dev_continuwuity-dev-data   <- survived
```

That last line is the failure mode being fixed. The e2e suite itself runs on this PR via the `e2e` workflow — I did not run the full suite locally.

## One-time cost

The dev project name changes from `dev` to `shape-rotator-dev`, so an existing `dev_continuwuity-dev-data` volume is orphaned and a fresh one created. Dev state is disposable (`down -v` is the documented reset), but it is a reset for anyone with a running dev stack.

## Why now

Unblocks running #77–#81 as parallel lanes instead of one at a time. #77 is currently running solo on zed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)