### PR TITLE
approver: session_id -> earliest-ts age index (#77, #76 chip 1)

### DIFF
--- a/.evidence/issue-77/flow.md
+++ b/.evidence/issue-77/flow.md
@@ -1,0 +1,57 @@
+# Evidence — issue #77 (session_id → age index, #76 chip 1) — Tier 1
+
+Issue `## Acceptance`: a test in `tests/` against the dev stack (style of
+`history_e2ee_repro.py` / `escrow_durability.py`) showing the bot builds a
+cleartext `room_id -> {session_id: earliest origin_server_ts}` index off
+`m.room.encrypted` events as they arrive in `/sync`, keeps the min ts per
+session, persists to `/data`, and survives a restart.
+
+Tier 1: **no user-visible surface** (internal crypto-state index consumed by
+later retention chips). The test transcript is the evidence — same convention
+as `tests/escrow_durability.py` (the #60 test this issue cites).
+
+## What was built
+- `knock-approver/approver.py`:
+  - `SESSION_INDEX_PATH` (`/data/session_age_index.json`, same `/data` trust
+    domain as `bot_crypto.db` and the escrow — #60 precedent).
+  - `record_session(room_id, session_id, ts)` — keeps the **minimum** ts,
+    persists atomically via the existing `_load`/`_save` helpers.
+  - `session_age_index(room_id) -> {session_id: earliest_ts}` — reads live
+    from the persisted file (restart-survival is structural, not a special case).
+  - `iter_encrypted_events(rooms_data)` — yields `(room_id, session_id,
+    origin_server_ts)` for every megolm `m.room.encrypted` timeline event,
+    cleartext (no decryption).
+  - Hooked into `sync_loop` after `handle_sync`; a write fault logs loudly
+    without killing the sync heartbeat. Missing file = first-boot `{}` (not an
+    error); a corrupt file RAISES via `_load` → `json.loads` (no silent skip of
+    state loss — the #60 convention).
+- `tests/session_age_index.py` — the acceptance test.
+
+## How to run (dev stack)
+```bash
+cd dev && docker compose up -d                # continuwuity on 127.0.0.1:46167
+docker run --rm --network host -v "$PWD:/repo" -w /repo \
+  shape-rotator-e2e-test-runner:latest python3 tests/session_age_index.py
+```
+
+## Result
+Transcript: `session_age_index.txt` — **9/9 checks passed, exit 0** (re-run on the
+branch rebased onto `staging` @ `128c5c8`; isolated dev lane
+`DEV_STACK_SUFFIX=-rw86 DEV_HS_PORT=46168` per #84):
+
+- forced rotation produced **2 distinct megolm session ids** (acceptance #2)
+- **every** `crypto_megolm_inbound_session` row has an index entry (acceptance #3)
+- each indexed ts == the earliest `origin_server_ts` for that session,
+  cross-checked against an authoritative `/messages` back-pagination (acceptance #4)
+- a **fresh Python process** re-imports `approver` against the persisted file and
+  re-reads the same index → survives a restart (acceptance #5)
+- the persisted `/data/session_age_index.json` exists on disk (size=190)
+
+Note: the `RuntimeError: database pool has been stopped` traceback printed
+*after* the `9/9 checks passed` line is mautrix teardown noise (the test closes
+`bot_db` then the background syncer handler fires once more). It occurs after
+all assertions and the `exit 0`; it is not a test failure.
+
+## Out of scope (per issue)
+Backfill of existing rooms, and any *use* of the index — those are retention
+epic chips 3 and 4.

--- a/.evidence/issue-77/session_age_index.txt
+++ b/.evidence/issue-77/session_age_index.txt
@@ -1,0 +1,21 @@
+[session_index] bot=@sai_bot_1787014408_54da:localhost:46167 alice=@sai_alice_1787014408_54da:localhost:46167
+[session_index] room=!ByjFI4a_t_QAhLOwxSmXALCgLsAuB1kbIMX-NSu0oS4
+Device @sai_alice_1787014408_54da:localhost:46167/ALICE744a isn't cross-signed
+Device @sai_bot_1787014408_54da:localhost:46167/BOT8fd5 isn't cross-signed
+Device @sai_bot_1787014408_54da:localhost:46167/BOT8fd5 isn't cross-signed
+Didn't find cross-signing key master of @sai_bot_1787014408_54da:localhost:46167
+Encryption info for !ByjFI4a_t_QAhLOwxSmXALCgLsAuB1kbIMX-NSu0oS4 not found in state store, fetching from server
+Failed to decrypt $XG5s0hDSr5ZLXCPgfltdLRAN1J2jY3NGgW706yGdSRY: Failed to decrypt megolm event: no session with given ID Jc4aujXRMUkpyUAReJkivmSnr84Mrh2zyjVgDrIszEU found
+  [PASS] bot received + indexed alice's first encrypted message  (1 encrypted event(s) recorded)
+Didn't find cross-signing key master of @sai_bot_1787014408_54da:localhost:46167
+  [PASS] rotation produced a second encrypted message after the drop  (1 encrypted event(s) recorded)
+  [PASS] >1 distinct megolm session exists (rotation worked)  (2 session(s): ['Jc4aujXRMUkpyUAReJkivmSnr84Mrh2zyjVgDrIszEU', 'XQI3UYB2a4iXG80OpcmbW38JqfDtJiDMcgwbfJ60mxE'])
+  [PASS] bot has >=2 inbound megolm sessions for the room  (2 inbound: ['Jc4aujXRMUkpyUAReJkivmSnr84Mrh2zyjVgDrIszEU', 'XQI3UYB2a4iXG80OpcmbW38JqfDtJiDMcgwbfJ60mxE'])
+[session_index] index[!ByjFI4a_t_QAhLOwxSmXALCgLsAuB1kbIMX-NSu0oS4] = {"Jc4aujXRMUkpyUAReJkivmSnr84Mrh2zyjVgDrIszEU": 1787014408702, "XQI3UYB2a4iXG80OpcmbW38JqfDtJiDMcgwbfJ60mxE": 1787014408714}
+  [PASS] every crypto_megolm_inbound_session has an index entry (#3)  (all 2 inbound covered)
+  [PASS] each indexed ts == earliest origin_server_ts for its session (#4)  (2 entries checked)
+  [PASS] index covers + is correct for every /messages session  (2 ground-truth session(s))
+  [PASS] index survives a process restart (#5)  (2 entry(ies) reloaded from session_age_index.json)
+  [PASS] persisted index file exists on disk (the restart source)  (session_age_index.json size=190)
+
+[session_index] 9/9 checks passed

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,32 +1,50 @@
-# PLAN — issue #60: escrow durability (megolm inbound sessions survive self-heal wipe)
+# PLAN — issue #77: session_id → age index (#76 chip 1)
 
-Branch: `ready-60` (base `staging`). Tier 1 (backend/self-heal; no UI surface).
+Derived from the issue's `## Acceptance`. Base: `staging`. Branch: `ready-77`.
 
-## Acceptance (from issue #60)
-A test in `tests/` (dev stack, style of `history_e2ee_repro.py`) showing:
-bot client receives an encrypted message → simulate re-mint (run the ACTUAL
-export/wipe/import functions with a NEW device_id + fresh store, not a
-hand-rolled imitation) → bot still decrypts the old message. Test run output
-in the PR. Tier 1: test transcript is the evidence.
+## Goal
+The bot must be able to tell how old a megolm session is. Build a cleartext
+index `room_id -> {session_id: earliest_origin_server_ts}` off `m.room.encrypted`
+events as they arrive in `/sync` (no decryption needed — `session_id` and
+`origin_server_ts` are cleartext). Persist to `/data`; survive restart; raise on
+read failure (no silent skip — issue #60 convention).
 
-## Tasks
-- [x] Read MATRIX_ONBOARDING.md (required), self_heal_unit.py, PR #59 primitive.
-- [x] Confirm mautrix API: `export_session(idx)->str`, `import_session(session_key,...)`,
-      `put_group_session`, enumerate via SQL on `crypto_megolm_inbound_session`.
-- [x] **approver.py**: add `ESCROW_PATH`, `export_inbound_sessions(cs)`,
-      `import_inbound_sessions(cs)` (raises on per-session failure, no skip),
-      `_export_escrow_for_wipe(mxid, old_device_id)` helper.
-- [x] **approver.py main()**: export BEFORE `_wipe_crypto_store()`.
-- [x] **approver.py sync_loop()**: import AFTER fresh store opens.
-- [x] **tests/escrow_durability.py**: bot devA receives+decrypts → export → wipe →
-      fresh store w/ NEW device_id → import → old msg still decrypts. Uses the
-      ACTUAL approver functions + sas_e2e helpers.
-- [x] Run the test against the dev stack (continuwuity in docker; test in the
-      `tests/Dockerfile` runner, `--network host`). Capture transcript.
-- [x] Commit (incl. transcript), push, open PR to staging. Remove `ready` label.
+## Work items (from the issue)
+- [x] `record_session(room_id, session_id, ts)` keeping the **minimum** ts, and
+      `session_age_index(room_id) -> {session_id: earliest_ts}` — added to
+      `knock-approver/approver.py` (matches the existing monolithic layout: the
+      #60 escrow helpers live here too).
+- [x] `iter_encrypted_events(rooms_data)` generator (style of
+      `iter_knock_events`) + hook into `sync_loop` after `handle_sync`, where
+      `m.room.encrypted` events are present.
+- [x] Persist to `/data/session_age_index.json` via the atomic `_load`/`_save`
+      helpers; the disk file is the source of truth on every call, so restart-
+      survival is structural, not a special case. Missing file = first-boot `{}`;
+      corrupt file propagates (raises) — no silent skip.
 
-## Notes (issue constraints)
-- plaintext in /data is fine (same trust domain as bot_crypto.db).
-- imported sessions carry forwarding chain / lower trust — expected.
-- keep the escrow file after import (it IS the durable escrow; replaced next wipe).
-- import MUST raise, never silently skip (no fallbacks).
+## Acceptance (restate) + how each is verified
+A test in `tests/` against the dev stack (style of `history_e2ee_repro.py` /
+`escrow_durability.py`) → `tests/session_age_index.py`.
+
+1. Bot creates a room and is present from event 0.
+2. Send messages, force at least one megolm rotation so >1 session exists.
+   → force rotation by `await alice.crypto.crypto_store
+     .remove_outbound_group_sessions([room_id])` before the 2nd send (mautrix
+     then mints a new outbound session_id on the next encrypt).
+3. Every session present in `crypto_megolm_inbound_session` has an index entry.
+   → query `SELECT session_id FROM crypto_megolm_inbound_session WHERE
+     account_id=bot AND room_id=room AND withheld_code IS NULL`, assert each is
+     in `session_age_index(room_id)`.
+4. Each indexed timestamp equals the `origin_server_ts` of the earliest event
+   that used that session.
+   → back-paginate `/messages`, group `m.room.encrypted` by `session_id`,
+     take `min(origin_server_ts)`, assert == indexed value for every session.
+5. Index survives a restart of the bot.
+   → fresh Python subprocess imports `approver` against the same persisted file
+     and re-reads `session_age_index(room_id)`; compare to in-process result.
+
+Evidence: transcript captured to `.evidence/issue-77/` (Tier 1 — no user-visible
+surface; matches the `escrow_durability.py` precedent cited by the issue via #60).
+
+## Out of scope (per issue)
+Backfill of existing rooms. Any *use* of the index — that's chips 3 and 4.

--- a/knock-approver/approver.py
+++ b/knock-approver/approver.py
@@ -92,6 +92,14 @@ CRYPTO_DB     = Path(os.environ.get("CRYPTO_DB", "/data/bot_crypto.db"))
 # (issue #60). Plaintext is fine: same /data volume + trust domain as
 # bot_crypto.db itself. The file IS the escrow — replaced on each wipe.
 ESCROW_PATH   = Path(os.environ.get("ESCROW_PATH", "/data/inbound_sessions.escrow.json"))
+# session_id -> earliest-seen origin_server_ts index, per room (issue #77, chip
+# 1 of the retention epic #76). Built cleartext off m.room.encrypted events as
+# they arrive in /sync (content.session_id + origin_server_ts, no decryption
+# needed) and persisted atomically. Answers "how old is the oldest message we
+# still hold for this megolm session". Same /data trust domain as bot_crypto.db
+# and the escrow (issue #60 precedent).
+SESSION_INDEX_PATH = Path(os.environ.get("SESSION_INDEX_PATH",
+                                         "/data/session_age_index.json"))
 
 # Set by sync_loop once the persistent Olm store is open.  The inviter-side
 # MSC4268 builder deliberately uses the same store as the running bot; a
@@ -434,6 +442,31 @@ def _endorser_for_code(code, fallback):
     endorser for those bot-autonomous flows)."""
     entry = _load(CODES_PATH).get(code) or {}
     return entry.get("minted_by") or fallback
+
+# --- session_id -> earliest-ts age index (issue #77) ---
+# The disk file is the source of truth: record_session loads-mutates-saves it on
+# every call, so a process restart between syncs sees the same index by
+# construction (no in-memory cache to lose). A missing file is a first-boot {}
+# (not an error); a corrupt file RAISES via _load (json.loads) — no silent skip
+# of state loss, the #60 convention.
+
+def record_session(room_id, session_id, ts):
+    """Record that megolm `session_id` was seen in `room_id` at ms-timestamp
+    `ts`, keeping the EARLIEST ts seen (the index answers 'how old is the oldest
+    message we still hold for this session'). Persists atomically. Existing
+    entries with a smaller ts are left untouched."""
+    ts = int(ts)
+    index = _load(SESSION_INDEX_PATH)
+    room = index.setdefault(room_id, {})
+    if session_id not in room or ts < room[session_id]:
+        room[session_id] = ts
+        _save(SESSION_INDEX_PATH, index)
+
+def session_age_index(room_id):
+    """Return {session_id: earliest_ts} for `room_id` (empty dict if the room
+    has no indexed sessions). Reads live from the persisted file, so a caller
+    always sees state that survives a restart."""
+    return dict(_load(SESSION_INDEX_PATH).get(room_id, {}))
 
 def merge_seed(path, env_key):
     """Merge JSON from env var into the codes file; only adds missing keys."""
@@ -782,6 +815,26 @@ def iter_knock_events(rooms_data):
                 if c.get("membership") != "knock":
                     continue
                 yield room_id, ev["state_key"], c.get("reason", "")
+
+
+def iter_encrypted_events(rooms_data):
+    """Yield (room_id, session_id, origin_server_ts) for every megolm
+    m.room.encrypted timeline event in a /sync batch, in arrival order.
+
+    session_id is a cleartext field on m.room.encrypted and origin_server_ts is
+    the event's top-level timestamp, so the session-age index (issue #77) can be
+    built WITHOUT decrypting anything. Events lacking session_id/ts (a non-megolm
+    or malformed shape) are skipped — a non-event, not a state read failure."""
+    for room_id, rd in rooms_data.get("join", {}).items():
+        for ev in rd.get("timeline", {}).get("events", []):
+            if ev.get("type") != "m.room.encrypted":
+                continue
+            c = ev.get("content") or {}
+            sid = c.get("session_id")
+            ts = ev.get("origin_server_ts")
+            if sid is None or ts is None:
+                continue
+            yield room_id, sid, int(ts)
 
 
 def iter_vetting_rooms(rooms_data, vetting_state):
@@ -2376,6 +2429,18 @@ async def sync_loop():
             v_dirty = True
         if v_dirty:
             _save(VETTING_PATH, vetting_state)
+
+        # session_id -> earliest-ts age index (retention epic #76, chip 1 / #77).
+        # Built cleartext off the m.room.encrypted events the bot just received;
+        # record_session keeps the min ts and persists atomically. Wrapped like
+        # announce_lobby_events above so a transient index-write fault logs
+        # loudly without killing the sync heartbeat (the next event re-records).
+        for rid, sid, its in iter_encrypted_events(data.get("rooms", {})):
+            try:
+                record_session(rid, sid, its)
+            except Exception as e:
+                print(f"[session_index error] {type(e).__name__}: {e}",
+                      flush=True)
 
         # Lobby flow runs in its own /sync loop (lobby_sync_loop) under the
         # dedicated onboarding-bot identity (LOBBY_TOKEN), so it doesn't appear

--- a/tests/session_age_index.py
+++ b/tests/session_age_index.py
@@ -1,0 +1,264 @@
+"""Issue #77 — session_id -> age index (chip 1 of the retention epic #76).
+
+`crypto_megolm_inbound_session` has no timestamp, so the bot can't tell how old a
+megolm session is. This pins down the fix: a cleartext index
+`room_id -> {session_id: earliest origin_server_ts}` built off `m.room.encrypted`
+events as they arrive in /sync (no decryption needed) and persisted to /data.
+
+Scenario (mirrors the issue's `## Acceptance`):
+  1. The BOT creates an E2EE room and is present from event 0.
+  2. alice joins and sends an encrypted message -> session S1.
+  3. alice's cached outbound session is dropped, forcing the next send to mint a
+     NEW megolm session S2 (mautrix: encrypt -> EncryptionError -> re-share).
+  4. The bot /syncs both batches, and the ACTUAL production hook
+     (approver.iter_encrypted_events + approver.record_session) records each
+     session_id with the earliest origin_server_ts seen, keeping the min.
+  5. Every inbound session in crypto_megolm_inbound_session has an index entry,
+     and each indexed ts equals the earliest event ts for that session
+     (cross-checked against an authoritative /messages back-pagination).
+  6. A FRESH python process re-imports approver against the persisted file and
+     reads the same index -> survives a restart.
+
+Run against the dev stack:
+  cd dev && docker compose up -d && python3 bootstrap.py
+  cd .. && python3 tests/session_age_index.py
+
+Tier 1: this transcript is the evidence (no user-visible surface); same
+convention as tests/escrow_durability.py (the #60 test the issue cites).
+"""
+import asyncio, json, os, secrets, subprocess, sys, time, urllib.parse, urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# --- Import approver (set the env it reads at module load), mirroring
+#     tests/escrow_durability.py. ---
+os.environ.setdefault("HS", os.environ.get("DEV_HS", "http://localhost:46167"))
+os.environ.setdefault("SPACE_ID", "!space:localhost")
+os.environ.setdefault("SPACE_CHILD_IDS", "")
+os.environ.setdefault("REG_TOKEN", "unused")
+os.environ.setdefault("ADMIN_COMMAND_ROOM", "!admin:localhost")
+os.environ.setdefault("CONDUWUIT_REGISTRATION_TOKEN",
+                      os.environ.get("DEV_REG_TOKEN", "dev-token"))
+sys.path.insert(0, str(REPO / "knock-approver"))
+sys.path.insert(0, str(REPO / "tests"))
+
+import approver  # noqa: E402  (must be after env setup)
+from sas_e2e import HS, _post, make_client, register, sync_once  # noqa: E402
+from mautrix.types import EventType, MessageType, TextMessageEventContent  # noqa: E402
+
+results = []
+def log(name, ok, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {name}" + (f"  ({detail})" if detail else ""), flush=True)
+    results.append((name, ok))
+
+
+def _get(url, token):
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+
+def encrypted_min_ts_by_session(room_id, token):
+    """Authoritative ground truth: back-paginate /messages and group every
+    m.room.encrypted event by content.session_id -> min(origin_server_ts)."""
+    by_sid = {}
+    frm = ""
+    for _ in range(10):
+        url = (f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(room_id)}"
+               f"/messages?dir=b&limit=100" + (f"&from={frm}" if frm else ""))
+        page = _get(url, token)
+        for raw in page.get("chunk", []):
+            if raw.get("type") != "m.room.encrypted":
+                continue
+            sid = (raw.get("content") or {}).get("session_id")
+            ts = raw.get("origin_server_ts")
+            if sid is None or ts is None:
+                continue
+            by_sid.setdefault(sid, ts)
+            if ts < by_sid[sid]:
+                by_sid[sid] = ts
+        frm = page.get("end")
+        if not frm:
+            break
+    return by_sid
+
+
+async def bot_sync_and_record(bot, bot_ss, first=False, timeout=5000):
+    """One bot /sync cycle that ALSO runs the production index hook: iterate
+    m.room.encrypted events off the raw sync dict and call approver.record_session
+    (the exact code path sync_loop runs), then handle_sync to decrypt + populate
+    the inbound store. Returns the raw sync dict."""
+    since = None if first else await bot.sync_store.get_next_batch()
+    data = await bot.sync(since=since, timeout=timeout, full_state=first)
+    if not isinstance(data, dict):
+        return None
+    nb = data.get("next_batch")
+    if nb:
+        await bot.sync_store.put_next_batch(nb)
+    # The production hook — record session ages BEFORE decrypting (issue #77).
+    n_recorded = 0
+    for rid, sid, its in approver.iter_encrypted_events(data.get("rooms", {})):
+        approver.record_session(rid, sid, its)
+        n_recorded += 1
+    bot_ss._joined.clear()
+    bot_ss._joined.update(data.get("rooms", {}).get("join", {}).keys())
+    tasks = bot.handle_sync(data)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    return data, n_recorded
+
+
+async def main():
+    suffix = f"{int(time.time())}_{secrets.token_hex(2)}"
+    bot_user = f"sai_bot_{suffix}"
+    bot_pw = secrets.token_urlsafe(32)
+    bot_dev = f"BOT{secrets.token_hex(2)}"
+    bot_mxid, bot_tok = register(bot_user, bot_pw, bot_dev)
+    alice_dev = f"ALICE{secrets.token_hex(2)}"
+    alice_mxid, alice_tok = register(f"sai_alice_{suffix}",
+                                     secrets.token_urlsafe(32), alice_dev)
+    print(f"[session_index] bot={bot_mxid} alice={alice_mxid}", flush=True)
+
+    # --- Temp /data surrogate so the test is isolated from the real volume. ---
+    tmp = Path(os.environ.get("SAI_TMP", "/tmp")) / f"session_index_{suffix}"
+    tmp.mkdir(parents=True, exist_ok=True)
+    index_path = tmp / "session_age_index.json"
+    approver.SESSION_INDEX_PATH = index_path
+    assert not index_path.exists(), "fresh workdir must not have an index yet"
+
+    # --- 1. BOT creates an E2EE room (present from event 0). ---
+    bot, bot_cs, bot_ss, bot_db = await make_client(
+        bot_mxid, bot_tok, bot_dev, tmp / "bot.db")
+    await bot.crypto.share_keys()
+    await bot_sync_and_record(bot, bot_ss, first=True)
+
+    s, r = _post(f"{HS}/_matrix/client/v3/createRoom", {
+        "name": "session age index",
+        "preset": "private_chat",
+        "initial_state": [
+            {"type": "m.room.history_visibility", "state_key": "",
+             "content": {"history_visibility": "shared"}},
+            {"type": "m.room.encryption", "state_key": "",
+             "content": {"algorithm": "m.megolm.v1.aes-sha2"}},
+        ],
+    }, token=bot_tok)
+    assert s == 200, f"createRoom: {s} {r}"
+    room_id = r["room_id"]
+    print(f"[session_index] room={room_id}", flush=True)
+
+    # --- alice invited + joins; both sync so devices + state propagate. ---
+    s, r = _post(f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(room_id)}/invite",
+                 {"user_id": alice_mxid}, token=bot_tok)
+    assert s == 200, f"invite: {s} {r}"
+    s, r = _post(f"{HS}/_matrix/client/v3/rooms/{urllib.parse.quote(room_id)}/join",
+                 {}, token=alice_tok)
+    assert s == 200, f"alice join: {s} {r}"
+
+    alice, alice_cs, alice_ss, alice_db = await make_client(
+        alice_mxid, alice_tok, alice_dev, tmp / "alice.db")
+    await alice.crypto.share_keys()
+    await sync_once(alice, alice_ss, first=True)
+    await sync_once(bot, bot_ss)   # bot sees alice join
+
+    # --- 2. alice sends M1 (auto-encrypts to the bot's device). ---
+    m1 = f"first-session {secrets.token_hex(4)}"
+    await alice.send_message_event(
+        room_id, EventType.ROOM_MESSAGE,
+        TextMessageEventContent(msgtype=MessageType.TEXT, body=m1))
+    _, n1 = await bot_sync_and_record(bot, bot_ss, timeout=5000)
+    await sync_once(alice, alice_ss, timeout=2000)
+    log("bot received + indexed alice's first encrypted message", n1 >= 1,
+        f"{n1} encrypted event(s) recorded")
+
+    # --- 3. FORCE a megolm rotation: drop alice's cached outbound session so
+    #     the next encrypt mints a NEW session id (mautrix: encrypt raises
+    #     EncryptionError -> re-share -> _new_outbound_group_session). ---
+    await alice.crypto.crypto_store.remove_outbound_group_sessions([room_id])
+    m2 = f"second-session {secrets.token_hex(4)}"
+    await alice.send_message_event(
+        room_id, EventType.ROOM_MESSAGE,
+        TextMessageEventContent(msgtype=MessageType.TEXT, body=m2))
+    _, n2 = await bot_sync_and_record(bot, bot_ss, timeout=5000)
+    log("rotation produced a second encrypted message after the drop", n2 >= 1,
+        f"{n2} encrypted event(s) recorded")
+
+    # --- ground truth from /messages (authoritative, complete room history). ---
+    ground = encrypted_min_ts_by_session(room_id, bot_tok)
+    log(">1 distinct megolm session exists (rotation worked)",
+        len(ground) >= 2, f"{len(ground)} session(s): {sorted(ground)}")
+
+    # --- the bot's inbound megolm sessions for this room. ---
+    rows = await bot_cs.db.fetch(
+        "SELECT session_id FROM crypto_megolm_inbound_session "
+        "WHERE account_id=$1 AND room_id=$2 AND withheld_code IS NULL",
+        bot_cs.account_id, room_id)
+    inbound = {str(row["session_id"]) for row in rows}
+    log("bot has >=2 inbound megolm sessions for the room",
+        len(inbound) >= 2, f"{len(inbound)} inbound: {sorted(inbound)}")
+
+    idx = approver.session_age_index(room_id)
+    print(f"[session_index] index[{room_id}] = {json.dumps(idx, sort_keys=True)}",
+          flush=True)
+
+    # --- Acceptance #3: every inbound session has an index entry. ---
+    missing = sorted(inbound - set(idx))
+    log("every crypto_megolm_inbound_session has an index entry (#3)",
+        not missing, f"missing: {missing}" if missing else
+        f"all {len(inbound)} inbound covered")
+
+    # --- Acceptance #4: each indexed ts == earliest event ts for that session. ---
+    bad = []
+    for sid, ts in idx.items():
+        if sid not in ground:
+            bad.append((sid, "no encrypted event uses this session", ts))
+        elif ts != ground[sid]:
+            bad.append((sid, f"index={ts} earliest={ground[sid]}", ts))
+    log("each indexed ts == earliest origin_server_ts for its session (#4)",
+        not bad, f"{len(idx)} entries checked" if not bad else f"{len(bad)} bad: {bad[:2]}")
+
+    # Index is a superset of ground truth (the bot may index its own outbound
+    # echoes too), but every session the bot can actually decrypt is covered +
+    # correct. Sanity: ground truth is fully present + correct in the index.
+    log("index covers + is correct for every /messages session",
+        all(sid in idx and idx[sid] == ts for sid, ts in ground.items()),
+        f"{len(ground)} ground-truth session(s)")
+
+    # --- Acceptance #5: survives a restart. A FRESH python process re-imports
+    #     approver against the persisted file and reads the same index. ---
+    env = {**os.environ, "SESSION_INDEX_PATH": str(index_path)}
+    script = (
+        "import sys; sys.path.insert(0, %r); import approver, json; "
+        "print(json.dumps(approver.session_age_index(%r), sort_keys=True))"
+        % (str(REPO / "knock-approver"), room_id))
+    try:
+        out = subprocess.check_output([sys.executable, "-c", script],
+                                      env=env, text=True, timeout=60)
+        restarted = json.loads(out.strip())
+        log("index survives a process restart (#5)",
+            restarted == idx,
+            f"{len(restarted)} entry(ies) reloaded from {index_path.name}"
+            if restarted == idx else f"reloaded={restarted} inproc={idx}")
+    except Exception as e:
+        log("index survives a process restart (#5)", False,
+            f"subprocess error: {type(e).__name__}: {e}")
+
+    # the persisted file is plain JSON on /data (survives a volume-preserving
+    # restart by construction); confirm it exists and is non-empty.
+    log("persisted index file exists on disk (the restart source)",
+        index_path.exists() and index_path.stat().st_size > 2,
+        f"{index_path.name} size={index_path.stat().st_size if index_path.exists() else 0}")
+
+    await bot_db.stop()
+    await bot.api.session.close()
+    await alice_db.stop()
+    await alice.api.session.close()
+
+    failed = [n for n, ok in results if not ok]
+    print(f"\n[session_index] {len(results) - len(failed)}/{len(results)} checks passed",
+          flush=True)
+    sys.exit(1 if failed else 0)
+
+
+asyncio.run(main())


### PR DESCRIPTION
## What it does
Adds a cleartext `room_id -> {session_id: earliest origin_server_ts}` index built off `m.room.encrypted` events as they arrive in `/sync` (`content.session_id` + `origin_server_ts` — no decryption needed), persisted atomically to `/data/session_age_index.json`. Keeps the **minimum** ts per `(room, session)`.

## What you get by merging
The bot can finally answer "how old is the oldest message I still hold for this megolm session?" — the prerequisite every later chip of the retention epic (#76) depends on. `crypto_megolm_inbound_session` has no timestamp column; this index is the gap-filler.

## Story
Closes #77 (chip 1 of #76). Restated `## Acceptance`:
1. Bot creates a room, present from event 0.
2. Send messages, force ≥1 megolm rotation so >1 session exists.
3. Every session in `crypto_megolm_inbound_session` has an index entry.
4. Each indexed ts == `origin_server_ts` of the earliest event using that session.
5. Index survives a restart of the bot.

## Evidence (Tier 1 — no user-visible surface)
`tests/session_age_index.py` against the dev stack (continuwuity on `127.0.0.1:46167`). Transcript in `.evidence/issue-77/session_age_index.txt` — **9/9 checks pass, exit 0**:
- forced rotation → **2 distinct megolm session ids** (acceptance #2)
- **every** `crypto_megolm_inbound_session` row has an index entry (acceptance #3)
- each indexed ts == earliest `origin_server_ts` vs an authoritative `/messages` back-pagination (acceptance #4)
- a **fresh Python process** re-imports `approver` against the persisted file and re-reads the same index (acceptance #5)

`Pinned /_api/version`: N/A — this is a Matrix/mautrix bot repo with no HTTP `_api/version` surface; the live dev-stack test transcript (the `escrow_durability.py` / #60 convention cited by the issue) is the Tier 1 artifact.

(The `RuntimeError: database pool has been stopped` line after `9/9 checks passed` is mautrix teardown noise — the test closes `bot_db` and the background syncer handler fires once more — not a failure.)

## Risk / what to watch
- New per-encrypted-event disk write in the sync hot path (load-mutate-save the small JSON each time). For this bot's message volume it's negligible; if a future high-volume room makes it matter, an in-memory cache flushed on sync is the knob.
- The hook logs and continues on write fault (mirrors `announce_lobby_events`) so the index can momentarily lag; the next encrypted event re-records. A **corrupt** index file raises at `_load` (loud, not silent) per the #60 convention.
- Out of scope (per issue): backfill of existing rooms; any *use* of the index — those are retention chips 3 and 4.

<details>
<summary>diff stats</summary>

```
 PLAN.md                    | 77 ++++++++++++++++------------
 knock-approver/approver.py | 65 ++++++++++++++++++++ 
 tests/session_age_index.py | (new)
 .evidence/issue-77/        | flow.md + session_age_index.txt (new)
```
</details>