### PR TITLE
Path A: <INVITER> placeholder + halt guard replaces socrates1024 hardcode (#2)

### DIFF
--- a/.evidence/issue-2/acceptance.log
+++ b/.evidence/issue-2/acceptance.log
@@ -1,0 +1,38 @@
+
+===== pre-flight =====
+[accept] repo:        /tmp/mx-2
+[accept] fixtures:    /home/amiller/.teleport-travel/test-fixtures.json
+[accept] creds:       /home/amiller/.shape-bridge-bot/creds.json
+[accept] state:       /home/amiller/.teleport-travel/relay-state.json
+[accept] full log:    /tmp/mx-2/.acceptance-logs/full.log  (mautrix stderr captured here; shown on failure)
+[accept] telegram api id: 20704355
+
+===== build runner image (tests/Dockerfile: libolm + mautrix) =====
+
+===== build acceptance image (runner + telethon + python-dotenv) =====
+[accept] PASS: images built
+
+===== baseline: relay --once (advance cursors to now) =====
+[accept] state before: {"tg_last_id": 23, "mx_seen": ["$U9tgD6nHM07WOiIkw6CT6CnJMn6egOphyAJs3QYEjIE", "$BXK8bzNp_hL1f75oEThkeUdfdPTrnFCXhrbCwbqt1k0", "$J52hG3WTV5wtZ5En7HpxpJftRjxotSdbho7gi3-yiGo", "$VwdLErI6wKv5gTxRUT5VG6SPoleSoNlC_YFytrpwoRU", "$XN6i2OV7FjN-glhbVWl3GZP766KBupekSjHIBlDCnnA", "$UpwJ6A9tRtCW6-8mTKxU0WL4aCoszYulwGvgYoV5Z94", "$V5rfbd1K3POaUFNGL8qubiV84qDjOvlZ8zgKUASNYc8", "$oel2yrKe9_OyWWseCtQUa6wr3vJc_ylW5R2SX9OkL1s", "$xAqdCxiMuCMMhPKCA3o9ryQkn3ES5--xljuw8RGP1fE", "$YOBhKQMifPxjVn40IUmLOnjQzhYmEEavKT1pMt7zDWE", "$QQwArqyEk4QxbxSFaMD6DJYYMrIPcpa1bvIVPgLbNNk", "$XQzIFo1dIwQMNmOonySXvvEagqtQVsx9PfeIwL-ft4o", "$f_N0vpN4WhApbn8aTm4mI2q5QPuTpObODEFqdHzuMdo", "$LJTLvYPocuZetkA_OZSLyKbhYxZOmvZO8HsLH9KPaDg", "$9YlliWSumfJfutbue4kH4mjwRSfReWrxPHQF_9Nqo4U", "$fVyocenBRBRGBOtWM84nJYKi9mD0a03Y_p9x9tcmQaM", "$QSVWW8baA02HJx7T7tQhmYjeZJW5J6tfRvmscohVDc0"]}
+[accept] state after:  {"tg_last_id": 23, "mx_seen": ["$U9tgD6nHM07WOiIkw6CT6CnJMn6egOphyAJs3QYEjIE", "$BXK8bzNp_hL1f75oEThkeUdfdPTrnFCXhrbCwbqt1k0", "$J52hG3WTV5wtZ5En7HpxpJftRjxotSdbho7gi3-yiGo", "$VwdLErI6wKv5gTxRUT5VG6SPoleSoNlC_YFytrpwoRU", "$XN6i2OV7FjN-glhbVWl3GZP766KBupekSjHIBlDCnnA", "$UpwJ6A9tRtCW6-8mTKxU0WL4aCoszYulwGvgYoV5Z94", "$V5rfbd1K3POaUFNGL8qubiV84qDjOvlZ8zgKUASNYc8", "$oel2yrKe9_OyWWseCtQUa6wr3vJc_ylW5R2SX9OkL1s", "$xAqdCxiMuCMMhPKCA3o9ryQkn3ES5--xljuw8RGP1fE", "$YOBhKQMifPxjVn40IUmLOnjQzhYmEEavKT1pMt7zDWE", "$QQwArqyEk4QxbxSFaMD6DJYYMrIPcpa1bvIVPgLbNNk", "$XQzIFo1dIwQMNmOonySXvvEagqtQVsx9PfeIwL-ft4o", "$f_N0vpN4WhApbn8aTm4mI2q5QPuTpObODEFqdHzuMdo", "$LJTLvYPocuZetkA_OZSLyKbhYxZOmvZO8HsLH9KPaDg", "$9YlliWSumfJfutbue4kH4mjwRSfReWrxPHQF_9Nqo4U", "$fVyocenBRBRGBOtWM84nJYKi9mD0a03Y_p9x9tcmQaM", "$QSVWW8baA02HJx7T7tQhmYjeZJW5J6tfRvmscohVDc0"]}
+[accept] PASS: baseline --once completed within 60s
+
+===== CHECK 1: TG -> MX (relay polls+handles a TG-side message in <10s) =====
+[accept] sent TG id=24 token=ACPT-TG2MX-1786834219-1939417262
+[accept] PASS: TG->MX: relay noticed+suppressed id=24 in 5s, cursor=24, no MX leak
+
+===== CHECK 2: MX -> TG (relay polls+handles a MX-side message in <10s) =====
+[accept] sent MX event_id=$0k5CPl3kwkpEVPv3ChKZHKlpQXRaPtLovWbxQ53OrxA token=ACPT-MX2TG-1786834219-1939417262
+[accept] PASS: MX->TG: relay noticed+suppressed $0k5CPl3kwkpEVPv3ChKZHKlpQXRaPtLovWbxQ53OrxA in 3s, marked seen, no TG leak
+
+===== CHECK 3: restart catch-up, exactly-once each direction =====
+[accept] downtime sends: TG id=25  MX event=$KjyCvOmEhnXdDpW3MdCcOqsmNEWe7UliUffVCf63dfQ
+[accept] PASS: restart #1 caught up both (TG id=25, MX $KjyCvOmEhnXdDpW3MdCcOqsmNEWe7UliUffVCf63dfQ)
+[accept] PASS: restart #2 re-processed neither (exactly-once confirmed; cursors stable)
+
+===== transcript summary =====
+[accept] tokens used: 1786834219-1939417262
+[accept] final relay state: {"tg_last_id": 25, "mx_seen": ["$U9tgD6nHM07WOiIkw6CT6CnJMn6egOphyAJs3QYEjIE", "$BXK8bzNp_hL1f75oEThkeUdfdPTrnFCXhrbCwbqt1k0", "$J52hG3WTV5wtZ5En7HpxpJftRjxotSdbho7gi3-yiGo", "$VwdLErI6wKv5gTxRUT5VG6SPoleSoNlC_YFytrpwoRU", "$XN6i2OV7FjN-glhbVWl3GZP766KBupekSjHIBlDCnnA", "$UpwJ6A9tRtCW6-8mTKxU0WL4aCoszYulwGvgYoV5Z94", "$V5rfbd1K3POaUFNGL8qubiV84qDjOvlZ8zgKUASNYc8", "$oel2yrKe9_OyWWseCtQUa6wr3vJc_ylW5R2SX9OkL1s", "$xAqdCxiMuCMMhPKCA3o9ryQkn3ES5--xljuw8RGP1fE", "$YOBhKQMifPxjVn40IUmLOnjQzhYmEEavKT1pMt7zDWE", "$QQwArqyEk4QxbxSFaMD6DJYYMrIPcpa1bvIVPgLbNNk", "$XQzIFo1dIwQMNmOonySXvvEagqtQVsx9PfeIwL-ft4o", "$f_N0vpN4WhApbn8aTm4mI2q5QPuTpObODEFqdHzuMdo", "$LJTLvYPocuZetkA_OZSLyKbhYxZOmvZO8HsLH9KPaDg", "$9YlliWSumfJfutbue4kH4mjwRSfReWrxPHQF_9Nqo4U", "$fVyocenBRBRGBOtWM84nJYKi9mD0a03Y_p9x9tcmQaM", "$QSVWW8baA02HJx7T7tQhmYjeZJW5J6tfRvmscohVDc0", "$0k5CPl3kwkpEVPv3ChKZHKlpQXRaPtLovWbxQ53OrxA", "$KjyCvOmEhnXdDpW3MdCcOqsmNEWe7UliUffVCf63dfQ"]}
+[accept] all three checks passed
+[accept] ACCEPTANCE PASSED (6 assertions)
+[accept] full transcript (incl. mautrix stderr): /tmp/mx-2/.acceptance-logs/full.log

--- a/.evidence/issue-2/flow.md
+++ b/.evidence/issue-2/flow.md
@@ -1,0 +1,38 @@
+=== TIER 1 TRANSCRIPT — issue #2 — 2026-08-15T22:50:54Z ===
+
+--- Step A: grep -rn socrates1024 skills/ (expect nothing, exit 1) ---
+exit=1
+
+--- Step B: Path A paste unmodified inviter (URL filled, <INVITER> left) ---
+exit=1 (halt = correct)
+
+--- Step C: inviter substituted (@somebody:matrix.org) ---
+    raise KeyError(key) from None
+KeyError: 'MATRIX_HOMESERVER'
+exit=1 (passes guard, stops at missing MATRIX_HOMESERVER env = pre-credential, no DM attempted)
+
+--- Step D: Path B untouched ---
+96:# Set by sync_loop once the persistent Olm store is open.  The inviter-side
+140:# Default inviter MXID to DM from the new account when someone signs up.
+141:# Per-code override: set "inviter" on the signup_codes.json entry.
+642:        "inviter": mxid,
+2358:        record_endorsement(entry.get("inviter") or entry.get("minted_by") or OUR_MXID,
+ PLAN.md                            | 151 +++----------------------------------
+ skills/matrix-invite-join/SKILL.md |   7 +-
+ 2 files changed, 18 insertions(+), 140 deletions(-)
+--- Step E: live GET directory/room (paste step 1, read-only, staging homeserver) ---
+alias resolves: !4FL8uL5OEYLATG1VH4wC2CD3pfIV6BMFId9VT7rmm-g servers: ['gitter.im', 'matrix.org', 'mtrx.shaperotator.xyz', 'unredacted.org']
+
+## Assertion vs issue #2 Acceptance
+1. `grep -rn socrates1024 skills/` → nothing (Step A above, exit=1). The :356 hit named in the
+   issue no longer existed on staging (removed by #67); only :41 remained and is now the
+   `<INVITER>` placeholder + adjacent substitution instruction (see diff).
+2. Unmodified paste (URL filled, inviter unreplaced) → HALT with substitution instruction
+   (Step B); no DM attempted, guard sits before env/credential access and before createRoom.
+   Substituted inviter → advances past guard (Step C).
+3. Path B untouched: knock-approver/approver.py unchanged in this diff; still derives
+   `inviter` from `entry.get("inviter") or ONBOARDING_INVITER_MXID` (per-code override).
+Lane gate bridge/acceptance.sh: PASSED, 6 assertions (acceptance.log).
+Not verified live: the actual DM send with a substituted inviter (flow step 3) — the fixture
+hard rule allows sending only to the single fixture room, while the DM step creates a new room
+and invites a user; verified instead up to the credential gate + live read-only alias resolve.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,143 +1,16 @@
-# PLAN — issue #62: MSC4268: send m.room_key_bundle on vetted invites
+# PLAN — issue #2: Path A inviter hardcode
 
-Branch: `ready-62` (base `staging`). Tier 1 (backend/bot; no UI surface).
-Depends on #61 (`build_room_key_bundle()`, merged) and #63 (invitee-side
-import, merged) — this chip is purely the inviter-side wiring: call the
-already-built builder after the bot's own invites and actually send the
-bundle.
+Base: origin/staging @ 32d5978. Tier 1 (paste-flow change; observable halt vs wrong-DM, no deployed UI).
 
-## Acceptance (from issue #62)
-E2e test in `tests/` (dev stack): existing member sends an encrypted
-message → new user is taken through a bot invite path → invitee client
-receives + olm-decrypts `m.room_key_bundle` from the bot, downloads/imports
-the bundle, and decrypts the pre-invite message. Plus: the endorsement
-JSONL contains the edge. Run output required (Tier 1). Element interop
-explicitly out of scope.
+## State found
+- skills/matrix-invite-join/SKILL.md:41 still hardcodes `@socrates1024:matrix.org`.
+- The `:356` hit named in the issue no longer exists on staging (removed by #67 / Paste C rework). Only :41 remains.
 
-## Design notes
-- MSC4268 requires the bundle sender to be the SAME identity that issued
-  the `m.room.member` invite. In this codebase that means: only invites
-  issued via the main bot's token (`TOKEN`/`AUTH`, the same identity as
-  `sync_loop`'s mautrix `client`) can carry a bundle. `_admin_invite` (used
-  by `_invite_to_children` and `signup_handler`) and `_promote` all use
-  that identity — safe to wire.
-- `_lobby_invite_to_space` invites as the *dedicated onboarding bot*
-  (`LOBBY_AUTH`), a different identity with no OlmMachine. Sending a
-  bundle from the main bot's crypto for an invite issued by a different
-  mxid would be silently rejected by the invitee's inviter-check (correct
-  behavior per MSC4268) — so this path does NOT get bundle wiring. It
-  still records the endorsement edge for the space invite. The actual
-  E2EE child-room invites in the lobby flow go through `_invite_to_children`
-  right after (main-bot identity), which does get the bundle.
-- Gate bundle-sending on the target room actually being E2EE with
-  `history_visibility` shared/world_readable (`_room_history_shareable`) —
-  a plain invite to the (non-encrypted) space is a correct no-op.
-- Endorsement JSONL reuses the existing `_load`/`_save`/`audit()` file
-  pattern (append-only JSONL, same shape as `LOG_PATH`) rather than a new
-  storage layer. `cmd_mint` gains a `minted_by` field on newly-minted code
-  entries so knock/lobby code-based endorsements can resolve the minter;
-  bot-autonomous invites (no resolvable code, e.g. `INITIAL_CODES`-seeded
-  entries) fall back to the bot's own mxid as endorser.
+## Checklist (from ## Acceptance)
+- [x] `grep -rn socrates1024 skills/` returns nothing → replace :41 with `<INVITER>` placeholder + adjacent substitution instruction
+- [x] Unmodified Path A paste halts on the unreplaced placeholder and asks for the inviter (explicit guard, raise SystemExit — not assert, which `-O` strips); never DMs a literal default
+- [x] Path B untouched — approver.py still derives `inviter = entry.inviter || ONBOARDING_INVITER_MXID`
+- [x] Verify: py_compile the paste body as extracted; simulate unmodified run → halt; simulate substituted run against homeserver-less stub (DM step would need real creds — checked by transcript of the halt + grep)
 
-## Tasks
-- [x] Read PLAN.md / STATE.md / MATRIX_ONBOARDING.md / issue #62 text.
-- [x] Locate every invite call site: `_invite_to_children`, `_promote`,
-      `_lobby_invite_to_space`, `_admin_invite` (signup_handler step 3).
-- [x] Add `_ROOM_KEY_BUNDLE_CLIENT` global (mirrors `_ROOM_KEY_BUNDLE_STORE`),
-      set in `sync_loop()`.
-- [x] Add `_room_history_shareable(room_id)` (encryption + history_visibility
-      check) and `_send_room_key_bundle(mxid, room_id)` (build + olm-send to
-      every device of `mxid`, best-effort, never raises into the caller).
-- [x] Add `ENDORSEMENTS_PATH` + `record_endorsement(endorser, invitee,
-      code_or_manual, room_id)` (JSONL append, same pattern as `audit()`).
-- [x] Wire `_invite_to_children`: on a fresh (200) child invite, send the
-      bundle + record the endorsement; skip on 403 (already member).
-- [x] Wire `_promote`: send bundle + record endorsement after a successful
-      space invite (no-op in practice since the space isn't E2EE, but the
-      hook is identity-correct if that ever changes).
-- [x] Wire `_lobby_invite_to_space`: record endorsement only (see design
-      notes — no bundle, identity mismatch).
-- [x] Wire `signup_handler` step 3 (`_admin_invite(mxid, SPACE_ID)`): send
-      bundle + record endorsement on success.
-- [x] `cmd_mint`: persist `minted_by` on newly minted codes.
-- [x] Thread `endorser` / `code_or_manual` through `process_vetting_room` and
-      `process_lobby_room` call sites (resolve from the code's `minted_by`,
-      fall back to the bot's own mxid).
-- [x] **tests/history_bundle_invite_e2e.py**: extend the chip-#61/#63 test
-      shape (`tests/history_bundle_e2e.py`, `tests/history_bundle_responder_e2e.py`)
-      to go through an actual `approver.py` invite path (not a hand-built
-      bundle): alice sends an encrypted message pre-invite → drive
-      `_invite_to_children` (or the vetting flow it's called from) for a
-      fresh invitee → invitee's `responder.py`-style client receives +
-      imports the olm-encrypted `m.room_key_bundle` → decrypts the
-      pre-invite message → assert the endorsement JSONL has the edge.
-      8/8 checks passed against the dev stack (transcript captured).
-- [x] Wired into `tests/run_in_runner.sh` (the PR gate) after
-      `history_bundle_responder_e2e.py`.
-- [x] Run against the dev stack (`dev/docker-compose up -d && python3
-      dev/bootstrap.py`), capture transcript as PR evidence. Also ran the
-      full `bash tests/run_e2e.sh` gate as a regression check (touched
-      shared functions `_invite_to_children`/`_promote`/
-      `_lobby_invite_to_space`/`signup_handler`/`cmd_mint` that other
-      gating tests exercise).
-- [x] Evidence written to `.evidence/issue-62/flow.md` +
-      `.evidence/issue-62/history_bundle_invite.txt` (repo convention from
-      #60/#61/#63).
-- [ ] Commit (incl. transcript), push, open PR to staging. Remove `ready`
-      label. (Left to the operator — see commit message / PR description
-      handed back in-conversation.)
-
----
-
-# PLAN — issue #78: retention room factory (#76 chip 2)
-
-Base: `staging`. Branch: `ready-78`. One issue, then stop.
-
-## Goal
-Bot-created "retention room": bot is sole PL100, E2EE on, `m.room.retention`
-state carries the policy window, restricted-join to the space + space-child link,
-a pinned plain-language policy message that does NOT overstate, and the policy is
-immutable at creation (the bot's in-force record is write-once; later
-`m.room.retention` changes are logged + noticed but never honored).
-
-Chip 3 (#79) will READ this in-force record to filter keys; chip 2 only creates
-the room + records the policy + refuses to honor later changes.
-
-## Acceptance (from issue body) → checkboxes
-- [ ] 1. Room created via the command (`!retention-room <name> <duration>`).
-- [ ] 2. `/state` shows bot at PL100 and **no other user at ≥50**; `users_default: 0`.
-- [ ] 3. `m.room.encryption` present; `m.room.retention` present with the window.
-- [ ] 4. Pinned policy message exists; text matches the configured window + is honest.
-- [ ] 5. Room is a space child; a space member can join without an invite.
-- [ ] 6. A later `PUT` of `m.room.retention` by another PL100 user (simulated)
-      does NOT change the bot's in-force policy record.
-
-## Work items
-1. `knock-approver/approver.py`:
-   - `RETENTION_PATH` config (default `/data/retention_rooms.json`) + load/save.
-   - `_parse_duration("7d")` → seconds (s/m/h/d/w).
-   - `_render_window(seconds)` → human label.
-   - `_retention_policy_text(name, window_seconds)` → pinned message (honest,
-     matches epic #76 "does / does not claim").
-   - `_create_retention_room(name, window_seconds)` → createRoom (bot sole PL100,
-     encryption, m.room.retention, restricted join to SPACE_ID), space-child link,
-     pinned policy message, write-once record. Returns dict with room_id.
-   - `cmd_retention_room(client, room_id, sender, args)` → parses, calls core,
-     returns reply. Register `"!retention-room"` in COMMANDS.
-   - sync_loop watcher: detect `m.room.retention` changes in retention rooms →
-     audit log + notice to OPERATOR_NOTIFY_ROOM; never mutate the store.
-2. `tests/retention_room_e2e.py` — self-contained, import-based (precedent:
-   `history_bundle_e2e.py` imports `approver` and calls the builder). Asserts 1–6.
-3. `tests/run_in_runner.sh` — wire the new test into the gate.
-
-## Verification (Tier 1 — API/backend behavior, no UI)
-Run `tests/retention_room_e2e.py` against the dev continuwuity stack
-(`localhost:46167`); capture transcript to `.evidence/issue-78/`. This service
-has no `/_api/version` (it's a Matrix bot, not a web app) — the lane-specific
-gate is the acceptance test transcript (matrix-ready-worker Step 4); I'll state
-that explicitly in the PR.
-
-## Out of scope (per epic #76)
-- Enforcement / key withholding — chip 3 (#79).
-- In-band transparency digests — chip 4 (#80).
-- Redaction sweep — chip 5 (#81).
+## Files
+- skills/matrix-invite-join/SKILL.md (line 41 region only)

--- a/skills/matrix-invite-join/SKILL.md
+++ b/skills/matrix-invite-join/SKILL.md
@@ -38,7 +38,12 @@ parsed = urlparse(invite_url)
 target_server = parsed.netloc                       # mtrx.shaperotator.xyz
 code          = parse_qs(parsed.query)["code"][0]
 alias         = f"#shape-rotator:{target_server}"
-inviter       = "@socrates1024:matrix.org"           # (the user who sent you)
+inviter       = "<INVITER>"  # the user who handed you this invite URL
+if inviter == "<INVITER>" or not inviter.startswith("@") or ":" not in inviter:
+    raise SystemExit(
+        "HALT — inviter not filled in. Replace <INVITER> with the full Matrix ID\n"
+        "(@name:server) of whoever actually sent you the invite link, then re-run.\n"
+        "Ask the user if you don't know. Never default to any other account.")
 
 HS, TOKEN = os.environ["MATRIX_HOMESERVER"].rstrip("/"), os.environ["MATRIX_ACCESS_TOKEN"]
 H = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}


### PR DESCRIPTION
## What it does
Replaces the hardcoded `@socrates1024:matrix.org` inviter in the Path A onboarding paste (`skills/matrix-invite-join/SKILL.md:41`) with an `<INVITER>` placeholder plus an adjacent instruction to substitute whoever actually handed you the invite link, and a guard that halts the paste before any credential access / network call / room creation if the placeholder is unreplaced.

## What you get by merging
No more wrong-DMs: an agent running Path A with the placeholder left in stops and asks for the inviter instead of silently DMing `socrates1024` (today: Seven invites James → James's agent says hi to socrates1024). With a real inviter substituted, the flow proceeds exactly as before.

## Story
Fixes #2 (option 2, as its acceptance was written for). Acceptance restated:
- `grep -rn socrates1024 skills/` returns nothing; both hits become an `<INVITER>` placeholder with an adjacent substitution line.
- An agent running the Path A paste **unmodified** halts on the unreplaced placeholder and asks for the inviter; never DMs a literal default.
- Path B untouched — `knock-approver/approver.py` still derives `inviter` from `entry.inviter || ONBOARDING_INVITER_MXID`, response still carries the pre-created DM room.

## Evidence (Tier 1)
Transcript committed to `.evidence/issue-2/flow.md` (full copy in `~/paseo-batch/out/2/`); key lines:

- **grep clean** — `grep -rn socrates1024 skills/` → no output, exit 1. Note: the `:356` hit named in the issue **no longer existed on staging** (removed by #67's Paste C rework) — only `:41` remained to fix.
- **Unmodified paste halts** (URL filled, `<INVITER>` unreplaced):
  ```
  HALT — inviter not filled in. Replace <INVITER> with the full Matrix ID
  (@name:server) of whoever actually sent you the invite link, then re-run.
  Ask the user if you don't know. Never default to any other account.
  ```
  `raise SystemExit` (not `assert`, which `-O` strips); guard sits before the `MATRIX_HOMESERVER` lookup and before `createRoom`, so no DM can be attempted with a literal default.
- **Substituted inviter advances** — `inviter = "@somebody:matrix.org"` passes the guard and proceeds to credential lookup (`KeyError: 'MATRIX_HOMESERVER'` without creds) — the guard is the only gate between "no inviter" and the DM.
- **Live, read-only, against deployed staging homeserver** — paste step 1 (alias resolve, GET) with the bridge-bot creds: `#shape-rotator:mtrx.shaperotator.xyz` → `!4FL8uL5OEYLATG1VH4wC2CD3pfIV6BMFId9VT7rmm-g`, servers `[gitter.im, matrix.org, mtrx.shaperotator.xyz, unredacted.org]`.
- **Lane gate** — `bridge/acceptance.sh`: PASSED, 6/6 assertions (TG→MX 5s, MX→TG 3s, restart exactly-once both directions); full log in `.evidence/issue-2/acceptance.log`.

## What I could NOT verify
The actual DM send with a substituted inviter (issue flow step 3, "DM lands in the fixture room"): the fixture hard rule permits sending only to the single fixture Matrix room, while the DM step creates a new room and invites a user. Verified instead up to the credential gate + the live read-only alias resolve above. The DM code path itself is unchanged from what shipped.

## Risk / what to watch
Docs-only diff (one skill paste + PLAN.md per repo convention). Worst case is an agent over-halting (asks for inviter when it already knows it) — fail-safe direction. Path B, approver, and bridge untouched; lane gate green confirms no collateral.

<details><summary>diff stats</summary>

```
 PLAN.md                            | 151 +++------------------------------
 skills/matrix-invite-join/SKILL.md |   7 +-
 2 files changed (+ .evidence/issue-2/)
```
</details>