### PR TITLE
Fix in-room SAS verification and responder startup

### DIFF
--- a/landing/responder.py
+++ b/landing/responder.py
@@ -39,6 +39,11 @@ from mautrix.util.async_db import Database
 
 from sas_verification import SASVerificationManager
 
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(name)s: %(message)s",
+)
+
 HS      = os.environ["HS"].rstrip("/")
 MXID    = os.environ["MXID"]
 TOKEN   = os.environ["TOKEN"]
@@ -218,11 +223,13 @@ async def main():
     client, cs, ss = await make_client()
     await client.crypto.share_keys()
     print(f"responder up as {MXID} device={DEVICE} ident={client.crypto.account.identity_key[:12]}...", flush=True)
-    SASVerificationManager(client, cs, MXID, DEVICE)
+    sas_manager = SASVerificationManager(client, cs, MXID, DEVICE)
     register_room_key_bundle_handler(client, cs, ss)
 
     async def on_msg(evt):
         if evt.sender == MXID:
+            return
+        if await sas_manager.handle_room_message(evt):
             return
         body = (getattr(evt.content, "body", "") or "").strip()
         cmd = body.split()[0] if body else ""
@@ -239,7 +246,7 @@ async def main():
     if DM_ROOM and INTRO:
         content = TextMessageEventContent(msgtype=MessageType.TEXT, body=INTRO)
         resp = await client.send_message_event(DM_ROOM, EventType.ROOM_MESSAGE, content)
-        print(f"POSTED:{resp.event_id}", flush=True)
+        print(f"POSTED:{resp}", flush=True)
 
     while True:
         try:

--- a/landing/sas_verification.py
+++ b/landing/sas_verification.py
@@ -40,7 +40,8 @@ class _SASSession:
     """State machine for one verification transaction."""
 
     def __init__(self, txn_id: str, their_user: str, their_device: str,
-                 our_user: str, our_device: str, client, crypto_store):
+                 our_user: str, our_device: str, client, crypto_store,
+                 room_id: str | None = None):
         import olm
         self.txn_id = txn_id
         self.their_user = their_user
@@ -49,12 +50,18 @@ class _SASSession:
         self.our_device = our_device
         self._client = client
         self._store = crypto_store
+        self._room_id = room_id
         self._sas = olm.Sas()
         self._start_event: dict | None = None
         self._cancelled = False
 
     async def _send(self, event_type: str, content: dict):
         from mautrix.types import EventType
+        if self._room_id:
+            room_content = {**content, "msgtype": event_type}
+            await self._client.send_message_event(
+                self._room_id, EventType.ROOM_MESSAGE, room_content)
+            return
         et = EventType.find(event_type, EventType.Class.TO_DEVICE)
         await self._client.send_to_device(
             et, {self.their_user: {self.their_device: content}})
@@ -188,7 +195,7 @@ class _SASSession:
 
 
 class SASVerificationManager:
-    """Handles all incoming verification to-device events."""
+    """Handles incoming to-device and in-room verification events."""
 
     def __init__(self, client, crypto_store, our_user: str, our_device: str):
         self._client = client
@@ -209,7 +216,8 @@ class SASVerificationManager:
             et = EventType.find(ev_type_str, EventType.Class.TO_DEVICE)
             client.add_event_handler(et, handler)
 
-    def _get_or_create(self, content: dict, sender: str) -> _SASSession | None:
+    def _get_or_create(self, content: dict, sender: str,
+                       room_id: str | None = None) -> _SASSession | None:
         txn_id = content.get("transaction_id")
         if not txn_id:
             return None
@@ -218,7 +226,7 @@ class SASVerificationManager:
             self._sessions[txn_id] = _SASSession(
                 txn_id, sender, their_device,
                 self._our_user, self._our_device,
-                self._client, self._store,
+                self._client, self._store, room_id=room_id,
             )
         return self._sessions[txn_id]
 
@@ -229,17 +237,19 @@ class SASVerificationManager:
             c = c.serialize()
         return c
 
-    async def _on_request(self, event):
+    async def _on_request(self, event, in_room=False):
         content = self._as_dict(event)
         sender = event.sender if hasattr(event, "sender") else event.get("sender", "")
-        sess = self._get_or_create(content, sender)
+        room_id = getattr(event, "room_id", None) if in_room else None
+        sess = self._get_or_create(content, sender, room_id=room_id)
         if sess:
             await sess.handle_request(content)
 
-    async def _on_start(self, event):
+    async def _on_start(self, event, in_room=False):
         content = self._as_dict(event)
         sender = event.sender if hasattr(event, "sender") else event.get("sender", "")
-        sess = self._get_or_create(content, sender)
+        room_id = getattr(event, "room_id", None) if in_room else None
+        sess = self._get_or_create(content, sender, room_id=room_id)
         if sess:
             await sess.handle_start(content)
 
@@ -261,3 +271,23 @@ class SASVerificationManager:
         txn_id = content.get("transaction_id")
         if txn_id:
             self._sessions.pop(txn_id, None)
+
+    async def handle_room_message(self, event) -> bool:
+        """Dispatch an in-room m.key.verification.* message.
+
+        Element sends these as ordinary m.room.message events. Returning a
+        boolean lets the responder keep command dispatch separate from SAS.
+        """
+        content = self._as_dict(event)
+        event_type = content.get("msgtype")
+        handler = {
+            "m.key.verification.request": self._on_request,
+            "m.key.verification.start": self._on_start,
+            "m.key.verification.key": self._on_key,
+            "m.key.verification.mac": self._on_mac,
+            "m.key.verification.cancel": self._on_cancel,
+        }.get(event_type)
+        if not handler:
+            return False
+        await handler(event, in_room=True)
+        return True

--- a/tests/sas_in_room_unit.py
+++ b/tests/sas_in_room_unit.py
@@ -1,0 +1,82 @@
+"""Focused regression check for Element's in-room SAS message transport."""
+import asyncio
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "landing"))
+
+import sas_verification as sas  # noqa: E402
+
+
+class _Client:
+    def __init__(self):
+        self.handlers = []
+        self.sent = []
+
+    def add_event_handler(self, event_type, handler):
+        self.handlers.append((event_type, handler))
+
+    async def send_message_event(self, room_id, event_type, content):
+        self.sent.append((room_id, event_type, content))
+        return "$room-reply"
+
+
+class _Event:
+    sender = "@alice:example.org"
+    room_id = "!dm:example.org"
+
+    def __init__(self, content):
+        self.content = content
+
+
+class _Session:
+    def __init__(self, txn_id, their_user, their_device, our_user,
+                 our_device, client, store, room_id=None):
+        self.room_id = room_id
+        self.calls = []
+
+    async def handle_request(self, content):
+        self.calls.append(("request", content))
+        await self._send("m.key.verification.ready", {
+            "transaction_id": content["transaction_id"]})
+
+    async def _send(self, event_type, content):
+        await self.client.send_message_event(self.room_id, "m.room.message",
+                                              {**content, "msgtype": event_type})
+
+
+async def main():
+    # Keep this test independent of libolm's cryptographic state machine: the
+    # regression is the event routing and the room reply transport.
+    original = sas._SASSession
+
+    def session(*args, **kwargs):
+        result = _Session(*args, **kwargs)
+        result.client = args[5]
+        return result
+
+    sas._SASSession = session
+    try:
+        client = _Client()
+        manager = sas.SASVerificationManager(client, object(),
+                                             "@bot:example.org", "BOT")
+        handled = await manager.handle_room_message(_Event({
+            "msgtype": "m.key.verification.request",
+            "transaction_id": "txn-1",
+            "from_device": "ALICE",
+        }))
+        assert handled
+        assert client.sent == [(
+            "!dm:example.org", "m.room.message", {
+                "transaction_id": "txn-1",
+                "msgtype": "m.key.verification.ready",
+            })
+        ]
+        print("PASS: in-room verification request routed and replied in-room")
+    finally:
+        sas._SASSession = original
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What it does
Routes Element's in-room `m.key.verification.*` messages through the SAS manager and sends replies back into the same DM. It also fixes the auto-intro event-id handling and enables INFO-level SAS logs.

## What you get by merging
Element's in-room Verify request is no longer dropped by the responder's command dispatcher; the responder stays alive after posting an intro and emits SAS protocol diagnostics.

## Story
Issue #40: https://github.com/teleport-computer/shape-rotator-matrix/issues/40

Acceptance implemented in code:
- In-room `m.room.message` verification events enter the SAS state machine and replies use the same room.
- `DM_ROOM` + `INTRO` prints `POSTED:<event_id>` using mautrix's string return value.
- SAS logs are configured at INFO, overridable with `LOG_LEVEL`.

## Evidence (Tier 2)
- Focused regression: `PASS: in-room verification request routed and replied in-room`.
- Full disposable E2E suite: all gating tests passed; existing to-device SAS reported `success=True trust=verified`.
- **Not yet complete:** no signed-in Element staging walk or committed screenshots of the green shield is available on this box. This PR must not receive `ready-to-merge` until that operator-dependent Tier-2 evidence is added.

## Risk / what to watch
In-room SAS replies are sent as `m.room.message` events with the verification event type as `msgtype`; verify the full Element emoji/green-shield flow on deployed staging before merging.

## BLOCKED — need from operator:
A signed-in Element session against deployed staging, with the real browser bridge available, to walk Verify to the green shield and commit `.evidence/issue-40/` screenshots plus `flow.md`.

<details>
<summary>Diff stats and verification</summary>

- `landing/responder.py`
- `landing/sas_verification.py`
- `tests/sas_in_room_unit.py`
- `PYTHONPYCACHEPREFIX=/tmp/mx-40-pycache python3.11 -m py_compile ...`
- `docker run ... shape-rotator-e2e-2074524728-test-runner python3 tests/sas_in_room_unit.py`
- `bash tests/run_e2e.sh`

</details>
